### PR TITLE
OVMS Home Assistant v0.3.17

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.3.15"
+  "version": "v0.3.17"
 }


### PR DESCRIPTION
# OVMS Home Assistant v0.3.17

Released on 2025-03-08

## What's Changed
## What's Changed

* OVMS Home Assistant v0.3.15 (#51)
* OVMS Home Assistant v0.3.9 (#50)
* OVMS Home Assistant v0.3.8 (#49)
* Release/v0.3.4 (#48)
* GitHub Actions: Bump actions/checkout from 3 to 4 (#47)
* Release/v0.4.0 test (#46)
* add network and system to diagnostic (#44)
* fix binary sensor logic (#43)
* fix #39 (#42)
* remove category from friendly name (#41)
* testing (7808a8c)
## Full Changelog
[v0.3.11...v0.3.17](https://github.com/enoch85/ovms-home-assistant/compare/v0.3.11...v0.3.17)
