### PR TITLE
OVMS Home Assistant v0.3.22

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.3.21"
+  "version": "v0.3.22"
 }


### PR DESCRIPTION
# OVMS Home Assistant v0.3.22

Released on 2025-03-08

## Changes

* Version bump to v0.3.22

## Full Changelog
[v0.3.21...v0.3.22](https://github.com/enoch85/ovms-home-assistant/compare/v0.3.21...v0.3.22)
