### PR TITLE
OVMS Home Assistant v0.1.0

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.3.23"
+  "version": "v0.1.0"
 }


### PR DESCRIPTION
# OVMS Home Assistant v0.1.0

Released on 2025-03-08

## Changes

* change version (7ac2206)
* AI nonsense (ed8e3ec)
* explanitory with read more tags (d066f69)
* better explination (8764321)

## Full Changelog
[v0.3.23...v0.1.0](https://github.com/enoch85/ovms-home-assistant/compare/v0.3.23...v0.1.0)
