### PR TITLE
OVMS Home Assistant v0.1.1

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.1.0"
+  "version": "v0.1.1"
 }

--- a/custom_components/ovms/metrics/common/battery.py
+++ b/custom_components/ovms/metrics/common/battery.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfLength,
     UnitOfPower,
+    UnitOfSpeed,
     UnitOfTemperature,
 )
 


### PR DESCRIPTION
# OVMS Home Assistant v0.1.1

Released on 2025-03-08

## Changes

* actually remove original metrics file (e06e280)
* make metrics more structured (9b39ecb)
* long and lat should be sensors, not device trackers (982a552)
* change to name of HA domain (99500e7)
* update name (c5afc75)

## Full Changelog
[v0.1.0...v0.1.1](https://github.com/enoch85/ovms-home-assistant/compare/v0.1.0...v0.1.1)
