### PR TITLE
OVMS Home Assistant v0.1.2

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.1.1"
+  "version": "v0.1.2"
 }


### PR DESCRIPTION
# OVMS Home Assistant v0.1.2

Released on 2025-03-08

## Changes

* Version bump to v0.1.2

## Full Changelog
[v0.1.1...v0.1.2](https://github.com/enoch85/ovms-home-assistant/compare/v0.1.1...v0.1.2)
