### PR TITLE
Release v0.3.0-beta

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.2.2"
+  "version": "v0.3.0-beta"
 }


### PR DESCRIPTION
🔬 **This is a beta release and may contain bugs or incomplete features**

# OVMS Home Assistant v0.3.0-beta

Released on 2025-03-10

### NOT TESTED before release.

## Changes

Mostly code refactoring, same functionality. Added security improvements.

* fix lint errors (part 3) (#70)
* fix lint errors (part 2) (#69)
* refactor to solve lint tests (part 1) (#68)

## Full Changelog
[v0.2.2...v0.3.0-beta](https://github.com/enoch85/ovms-home-assistant/compare/v0.2.2...v0.3.0-beta)
