### PR TITLE
Release v0.3.1

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.3.0-beta3"
+  "version": "v0.3.1"
 }


### PR DESCRIPTION
# OVMS Home Assistant v0.3.1

Released on 2025-03-11

## Changes

* change /status topic to regular sensor (#75)

## Full Changelog
[v0.3.0-beta3...v0.3.1](https://github.com/enoch85/ovms-home-assistant/compare/v0.3.0-beta3...v0.3.1)
