### PR TITLE
Release v0.4.0-beta1

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.3.1"
+  "version": "v0.4.0-beta1"
 }


### PR DESCRIPTION
🔬 **This is a beta release and may contain bugs or incomplete features**

# OVMS Home Assistant v0.4.0-beta1

Released on 2025-03-11

## Changes

* Version bump to v0.4.0-beta1

## Full Changelog
[v0.3.1...v0.4.0-beta1](https://github.com/enoch85/ovms-home-assistant/compare/v0.3.1...v0.4.0-beta1)
