### PR TITLE
Release v0.5.2

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.5.1-beta1"
+  "version": "v0.5.2"
 }


### PR DESCRIPTION
# OVMS Home Assistant v0.5.2

Released on 2025-03-12

## Changes

* remove vehicle_id from friendly name (554e190)
* Update entity_factory.py (7bdd886)
* properly import firmware info to device info (07f409e)

## Full Changelog
[v0.5.1-beta1...v0.5.2](https://github.com/enoch85/ovms-home-assistant/compare/v0.5.1-beta1...v0.5.2)
