### PR TITLE
Release v0.8.0

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.7.0"
+  "version": "v0.8.0"
 }


### PR DESCRIPTION
# OVMS Home Assistant v0.8.0

Released on 2025-03-15

## Changes

* Improve SSL/TLS option (#104)
* final fix for topic discovery text (#103)
* try to fix broker_note not being shown (#102)
* improve vehicle_id parsing (#101)

## Full Changelog
[v0.7.0...v0.8.0](https://github.com/enoch85/ovms-home-assistant/compare/v0.7.0...v0.8.0)
