### PR TITLE
Release v0.8.1

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v0.8.1-beta3"
+  "version": "v0.8.1"
 }


### PR DESCRIPTION
# OVMS Home Assistant v0.8.1

Released on 2025-03-16

## Changes

* add missing units (#113) (0b78905)

## Full Changelog
[v0.8.1-beta2...v0.8.1](https://github.com/enoch85/ovms-home-assistant/compare/v0.8.1-beta2...v0.8.1)
