### PR TITLE
Workaround vehicle locked status

### DIFF
--- a/custom_components/ovms/metrics/common/door.py
+++ b/custom_components/ovms/metrics/common/door.py
@@ -61,5 +61,6 @@ DOOR_METRICS = {
         "icon": "mdi:lock",
         "device_class": BinarySensorDeviceClass.LOCK,
         "category": "door",
+        "invert_state": True,  # Added to fix inverted reporting from OVMS
     },
 }


### PR DESCRIPTION
it seems like the code is correct but the data from OVMS are reversed. Workaround this by reversing the state of the sensor.

Fix https://github.com/enoch85/ovms-home-assistant/issues/107

@andlo Please test.