### PR TITLE
Potential fix for code scanning alert no. 24: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/ovms/device_tracker.py
+++ b/custom_components/ovms/device_tracker.py
@@ -350,8 +350,7 @@ class OVMSDeviceTracker(TrackerEntity, RestoreEntity):
                     self._attr_extra_state_attributes["last_updated"] = dt_util.utcnow().isoformat()
 
                 if coordinates_changed:
-                    _LOGGER.debug("Updated device tracker coordinates: lat=%s, lon=%s",
-                                 self._latitude, self._longitude)
+                    _LOGGER.debug("Updated device tracker coordinates.")
 
             # Add sensible default for gps_accuracy if necessary
             if "gps_accuracy" not in self._attr_extra_state_attributes:


### PR DESCRIPTION
Potential fix for [https://github.com/enoch85/ovms-home-assistant/security/code-scanning/24](https://github.com/enoch85/ovms-home-assistant/security/code-scanning/24)

To fix the problem, we should avoid logging sensitive information such as coordinates in clear text. Instead, we can log a message indicating that the coordinates have been updated without including the actual values. This way, we maintain the functionality of logging updates without exposing sensitive data.

- Replace the log message on line 354 to avoid logging the actual latitude and longitude values.
- Ensure that the new log message still provides useful information for debugging purposes without revealing sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
