### PR TITLE
Fix: Implement stable MQTT client ID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ The integration implements stable MQTT client ID management:
 - **Stable Client IDs**: Generates unique, persistent client IDs based on broker host and vehicle ID
 - **Format**: `ha_ovms_xxxxxxxxxxxx` (20 characters total)
 - **Compatibility**: Works with all MQTT versions (3.1, 3.1.1, and 5.0)
-- **Collision Resistance**: Uses MD5 hash with 281 trillion possible combinations
+- **Collision Resistance**: Uses SHA-256 hash with 281 trillion possible combinations
 - **Migration Support**: Automatically migrates existing installations to stable client IDs
 
 This ensures reliable MQTT connections and prevents authentication issues caused by rapidly changing client identifiers.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The OVMS integration discovers and creates Home Assistant entities from MQTT top
 
 - Home Assistant (2025.2.5 or newer) according to HACS specification
 - MQTT integration configured in Home Assistant
+- MQTT broker supporting MQTT 3.1, 3.1.1, or 5.0 (client ID length limit: 23 characters for 3.1/3.1.1)
 - OVMS module publishing to the same MQTT broker
 - OVMS firmware 3.3.001 or newer recommended (3.3.004+ for optimal performance)
 - Python package: paho-mqtt>=1.6.1 (installed automatically)
@@ -536,6 +537,18 @@ The integration implements sophisticated topic discovery:
 - **Adaptive Subscription**: Subscribes to identified pattern for ongoing communication
 
 This allows the integration to work even when the exact topic structure isn't known in advance.
+
+### MQTT Connection Management
+
+The integration implements stable MQTT client ID management:
+
+- **Stable Client IDs**: Generates unique, persistent client IDs based on broker host and vehicle ID
+- **Format**: `ha_ovms_xxxxxxxxxxxx` (20 characters total)
+- **Compatibility**: Works with all MQTT versions (3.1, 3.1.1, and 5.0)
+- **Collision Resistance**: Uses MD5 hash with 281 trillion possible combinations
+- **Migration Support**: Automatically migrates existing installations to stable client IDs
+
+This ensures reliable MQTT connections and prevents authentication issues caused by rapidly changing client identifiers.
 
 ### Entity Classification
 

--- a/custom_components/ovms/__init__.py
+++ b/custom_components/ovms/__init__.py
@@ -176,11 +176,11 @@ async def _migrate_client_id(hass: HomeAssistant, config_entry: ConfigEntry, fro
                   from_version, repr(host), repr(username), repr(vehicle_id))
     
     client_id_base = f"{host}_{username}_{vehicle_id}"
-    client_id = f"ha_ovms_{hashlib.md5(client_id_base.encode()).hexdigest()[:12]}"
+    client_id = f"ha_ovms_{hashlib.sha256(client_id_base.encode()).hexdigest()[:12]}"
     
     # Debug: Log the hash input and output
     _LOGGER.debug("V%d Migration: Hash input: %s", from_version, repr(client_id_base))
-    _LOGGER.debug("V%d Migration: Generated hash: %s", from_version, hashlib.md5(client_id_base.encode()).hexdigest()[:12])
+    _LOGGER.debug("V%d Migration: Generated hash: %s", from_version, hashlib.sha256(client_id_base.encode()).hexdigest()[:12])
     
     # Update the config entry data
     current_data[CONF_CLIENT_ID] = client_id

--- a/custom_components/ovms/__init__.py
+++ b/custom_components/ovms/__init__.py
@@ -170,6 +170,9 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     try:
         version = config_entry.version
 
+        # Always check for missing client_id regardless of version
+        await _migrate_client_id(hass, config_entry, version)
+
         # If the config entry is already up-to-date, return True
         if version == CONFIG_VERSION:
             return True
@@ -180,9 +183,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         if version in [1, 2]:
             # Migrate blacklist patterns to clean format
             await _migrate_blacklist_patterns(hass, config_entry, version)
-
-        # Add stable MQTT client ID if missing (for all versions < 3)
-        await _migrate_client_id(hass, config_entry, version)
 
         # Update the config entry version
         hass.config_entries.async_update_entry(config_entry, version=CONFIG_VERSION)

--- a/custom_components/ovms/config_flow/__init__.py
+++ b/custom_components/ovms/config_flow/__init__.py
@@ -32,6 +32,7 @@ from ..const import (
     CONF_TOPIC_STRUCTURE,
     CONF_VERIFY_SSL,
     CONF_ORIGINAL_VEHICLE_ID,
+    CONF_CLIENT_ID,
     TOPIC_STRUCTURES,
     LOGGER_NAME,
 )
@@ -413,6 +414,12 @@ class OVMSConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
+
+                # Generate a stable MQTT client ID based on the same unique data
+                client_id_base = f"{self.mqtt_config[CONF_HOST]}_{user_input[CONF_VEHICLE_ID]}"
+                client_id = f"ha_ovms_{hashlib.md5(client_id_base.encode()).hexdigest()[:12]}"
+                self.mqtt_config[CONF_CLIENT_ID] = client_id
+                _LOGGER.debug("Generated stable MQTT client ID: %s", client_id)
 
                 # Ensure everything is serializable
                 self.mqtt_config["debug_info"] = self._ensure_serializable(self.debug_info)

--- a/custom_components/ovms/config_flow/__init__.py
+++ b/custom_components/ovms/config_flow/__init__.py
@@ -419,7 +419,7 @@ class OVMSConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Multiple users can have same vehicle_id, but username must be unique on broker
                 # Hash input combines all unique identifiers but keeps username private
                 client_id_base = f"{self.mqtt_config[CONF_HOST]}_{self.mqtt_config[CONF_USERNAME]}_{user_input[CONF_VEHICLE_ID]}"
-                client_id = f"ha_ovms_{hashlib.md5(client_id_base.encode()).hexdigest()[:12]}"
+                client_id = f"ha_ovms_{hashlib.sha256(client_id_base.encode()).hexdigest()[:12]}"
                 self.mqtt_config[CONF_CLIENT_ID] = client_id
                 _LOGGER.debug("Generated stable MQTT client ID: %s", client_id)
 

--- a/custom_components/ovms/config_flow/__init__.py
+++ b/custom_components/ovms/config_flow/__init__.py
@@ -415,8 +415,10 @@ class OVMSConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
 
-                # Generate a stable MQTT client ID based on the same unique data
-                client_id_base = f"{self.mqtt_config[CONF_HOST]}_{user_input[CONF_VEHICLE_ID]}"
+                # Generate a stable MQTT client ID including username to prevent collisions
+                # Multiple users can have same vehicle_id, but username must be unique on broker
+                # Hash input combines all unique identifiers but keeps username private
+                client_id_base = f"{self.mqtt_config[CONF_HOST]}_{self.mqtt_config[CONF_USERNAME]}_{user_input[CONF_VEHICLE_ID]}"
                 client_id = f"ha_ovms_{hashlib.md5(client_id_base.encode()).hexdigest()[:12]}"
                 self.mqtt_config[CONF_CLIENT_ID] = client_id
                 _LOGGER.debug("Generated stable MQTT client ID: %s", client_id)

--- a/custom_components/ovms/const.py
+++ b/custom_components/ovms/const.py
@@ -31,7 +31,6 @@ CONF_DELETE_STALE_HISTORY = "delete_stale_history"  # Delete history when hiding
 DEFAULT_PORT = 1883
 DEFAULT_QOS = 1
 DEFAULT_PROTOCOL = "mqtt"
-DEFAULT_CLIENT_ID = "homeassistant_ovms"
 DEFAULT_TOPIC_PREFIX = "ovms"
 DEFAULT_SCAN_INTERVAL = 60
 DEFAULT_UNIT_SYSTEM = "metric"

--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.4.5-beta1"
+  "version": "v1.4.5-beta2"
 }

--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.4.5-beta3"
+  "version": "1.4.5"
 }

--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.4.4"
+  "version": "v1.4.5-beta1"
 }

--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.4.5-beta2"
+  "version": "v1.4.5-beta3"
 }

--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "1.4.5"
+  "version": "1.4.4"
 }

--- a/custom_components/ovms/mqtt/connection.py
+++ b/custom_components/ovms/mqtt/connection.py
@@ -117,7 +117,7 @@ class MQTTConnectionManager:
             # Include username to prevent collisions when multiple users have same vehicle_id
             # Hash input combines unique identifiers while keeping username private in logs
             client_id_base = f"{host}_{username}_{vehicle_id}"
-            client_id = f"ha_ovms_{hashlib.md5(client_id_base.encode()).hexdigest()[:12]}"
+            client_id = f"ha_ovms_{hashlib.sha256(client_id_base.encode()).hexdigest()[:12]}"
             _LOGGER.warning("Client ID was missing, generated stable fallback: %s", client_id)
         
         protocol = mqtt.MQTTv5 if hasattr(mqtt, "MQTTv5") else mqtt.MQTTv311

--- a/custom_components/ovms/mqtt/connection.py
+++ b/custom_components/ovms/mqtt/connection.py
@@ -105,6 +105,7 @@ class MQTTConnectionManager:
     async def _create_mqtt_client(self) -> mqtt.Client:
         """Create and configure the MQTT client."""
         client_id = self.config.get(CONF_CLIENT_ID)
+        _LOGGER.debug("MQTT Connection: client_id from config: %s", client_id)
         
         # Fallback: generate stable client_id if missing (should not happen after migration)
         if not client_id:
@@ -112,6 +113,7 @@ class MQTTConnectionManager:
             host = self.config.get(CONF_HOST, "unknown")
             username = self.config.get(CONF_USERNAME, "unknown")
             vehicle_id = self.config.get(CONF_VEHICLE_ID, "unknown")
+            _LOGGER.debug("MQTT Connection: Fallback values - host=%s, username=%s, vehicle_id=%s", host, username, vehicle_id)
             # Include username to prevent collisions when multiple users have same vehicle_id
             # Hash input combines unique identifiers while keeping username private in logs
             client_id_base = f"{host}_{username}_{vehicle_id}"


### PR DESCRIPTION
Resolves MQTT connection issues by implementing stable client ID generation and addresses GitHub Security Advisory for cryptographic hash algorithms.

**Changes:**
- Generate stable 20-character client IDs using SHA-256 hash of host+username+vehicle_id  
- Add automatic migration for existing installations
- Ensure MQTT 3.1/3.1.1 compatibility (23-character limit)
- Remove unused DEFAULT_CLIENT_ID constant
- Update documentation with MQTT requirements
- Upgrade from MD5 to SHA-256 for improved security compliance

**Impact:**
- Prevents authorization issues from random client ID changes
- Improves connection stability and debugging capability  
- Maintains backward compatibility with automatic migration
- Addresses GitHub Advanced Security findings
- **First restart may cause a brief MQTT reconnection as client ID is upgraded**
- **This is a one-time occurrence for improved security and stability**

**Security:**
- Resolves use of weak cryptographic algorithm (MD5 → SHA-256)
- Client ID collision resistance with 281 trillion possible combinations
- Privacy-conscious hashing keeps usernames private in generated client IDs