### PR TITLE
fix: Nissan Leaf Hx description, icon, units

### DIFF
--- a/custom_components/ovms/metrics/vehicles/nissan_leaf.py
+++ b/custom_components/ovms/metrics/vehicles/nissan_leaf.py
@@ -134,10 +134,12 @@ NISSAN_LEAF_METRICS = {
         "category": "nissan_leaf",
     },
     "xnl.v.b.hx": {
-        "name": "Nissan Leaf Heat Exchange",
-        "description": "Battery heat exchange value",
-        "icon": "mdi:heat-wave",
+        "name": "Nissan Leaf Battery Hx",
+        "description": "Battery conductance relative to new",
+        "icon": "mdi:resistor",
+        "device_class": SensorDeviceClass.BATTERY,
         "state_class": SensorStateClass.MEASUREMENT,
+        "unit": PERCENTAGE,
         "category": "nissan_leaf",
     },
     "xnl.v.b.max.gids": {


### PR DESCRIPTION
References
* https://www.reddit.com/r/leaf/comments/moim5e/comment/gu4se00/
* https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Help-1.5.0.pdf page 16
   > **Hx** The meaning of this number is not fully understood but it appears to be inversely related to the battery internal resistance. As the internal resistance of the battery pack increases it is thought this percentage decreases. As internal resistance increases more energy is lost within the pack and the pack heats up more under load.
