### PR TITLE
Add .claude config for AI-assisted contributors

### DIFF
--- a/.claude/rules/implementation.md
+++ b/.claude/rules/implementation.md
@@ -1,0 +1,1 @@
+At the start of every conversation, read [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md) and follow it for project-specific guidance on conventions, constants usage, code-quality checks, formatting, and release workflow.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "attribution": {
+    "commit": ""
+  }
+}


### PR DESCRIPTION
## Summary

Adds a minimal `.claude/` directory so AI-assisted contributions follow project conventions and stay out of git attribution.

## What's in it

- **`.claude/settings.json`** — sets `attribution.commit: ""` to suppress the default `Co-Authored-By: Claude ...` trailer on commits.
- **`.claude/rules/implementation.md`** — instructs Claude to read [`.github/copilot-instructions.md`](.github/copilot-instructions.md) at the start of every session, so project conventions (constants from `const.py`, code-quality checks, black formatting, release workflow) are followed from the first action.

## Notes

- `.claude/settings.local.json` is already gitignored globally — not affected.
- No behavioral change to the integration itself.