### PR TITLE
Fix cabin temperature setpoint misclassified as switch (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,16 +257,25 @@ The default blacklist now also includes `event`, which blocks high-frequency eve
 - `gps.log` - Blocks GPS log specific topics
 - `xrt.log` - Blocks Renault Twizy specific log topics
 
-### Lock PIN Behavior
+### PIN Behavior
 
-The native Home Assistant lock entity supports OVMS lock and unlock commands.
+The native Home Assistant lock entity supports OVMS lock and unlock commands. The same stored PIN is also automatically applied to the valet/unvalet switch when present.
 
-- The stored lock PIN option is only shown when using a verified secure MQTT connection (`mqtts://` or `wss://` with certificate verification enabled).
-- If you save a stored lock PIN in the integration options, the Home Assistant lock dialog can be left blank and the stored value will be used as a fallback.
-- If you do not save a stored lock PIN, Home Assistant will require you to enter one when using the lock entity.
-- OVMS itself registers `lock` and `unlock` as commands that take one PIN argument. Some vehicle modules validate that PIN, while others ignore it. If your vehicle does not actually validate the PIN, you may still need to configure a simple placeholder value so the command has the required argument. A value like `nopin` is a safe example.
+OVMS firmware registers `lock`, `unlock`, `valet` and `unvalet` as commands that take **exactly one** PIN argument — the firmware shell rejects argument-less calls with `Usage: ...`. Some vehicle modules validate that argument as a real PIN, while others (notably Fiat 500e, where `valet` is repurposed as a climate-control trigger) ignore the value entirely.
+
+**Lock entity:**
+- The stored PIN option is only shown when using a verified secure MQTT connection (`mqtts://` or `wss://` with certificate verification enabled).
+- If you save a stored PIN in the integration options, the Home Assistant lock dialog can be left blank and the stored value will be used as a fallback.
+- If you do not save a stored PIN, Home Assistant will require you to enter one when using the lock entity.
+- If your vehicle does not actually validate the PIN, you can configure a simple placeholder value (e.g. `nopin`) so the command has the required argument.
+
+**Valet/unvalet switch:**
+- Home Assistant switches cannot prompt for a code per toggle, so the integration uses the stored PIN automatically when one is configured (over verified TLS).
+- If no stored PIN is configured, the integration sends the placeholder `nopin` so the OVMS shell accepts the command. This is enough for vehicles that ignore the PIN value (e.g. Fiat 500e — valet engages climate control). Vehicles that *validate* the PIN will reject the command; the integration logs a warning when OVMS replies with `Error: ...` or `Usage: ...` so the failure is visible in your Home Assistant log.
+
+**General:**
 - PIN values cannot contain spaces or other whitespace.
-- The lock PIN is stored in Home Assistant's config entry storage (`.storage/core.config_entries`). Home Assistant does not encrypt config entries at rest. The PIN is masked in the UI and redacted in logs, but be aware it is stored in plaintext on disk, as is standard for all HA integration credentials.
+- The PIN is stored in Home Assistant's config entry storage (`.storage/core.config_entries`). Home Assistant does not encrypt config entries at rest. The PIN is masked in the UI and redacted in logs, but be aware it is stored in plaintext on disk, as is standard for all HA integration credentials.
 
 ### Testing Configuration
 

--- a/custom_components/ovms/const.py
+++ b/custom_components/ovms/const.py
@@ -54,6 +54,19 @@ PIN_SECURE_PROTOCOLS = ("mqtts", "wss")
 PIN_SENSITIVE_COMMANDS = ("lock", "unlock", "valet", "unvalet")
 SENSITIVE_LOG_REDACTION = "***"
 
+# OVMS firmware registers lock/unlock/valet/unvalet with min=max=1 argument
+# (RegisterCommand("...", ..., "<pin>", 1, 1) in vehicle.cpp). The shell
+# rejects the command with "Usage: ..." if no argument is supplied, even on
+# vehicle modules that ignore the PIN value (e.g. Fiat 500e, where the
+# valet command is repurposed as a climate-control trigger). Switch entities
+# cannot prompt for a PIN per toggle, so when no stored PIN is configured we
+# send this neutral placeholder to satisfy the shell. Vehicle modules that
+# validate the PIN will reject it cleanly (logged as a warning); modules
+# that ignore the PIN will execute the command. README documents "nopin" as
+# the recommended user-supplied placeholder for the lock entity — reusing
+# the same string keeps the convention consistent.
+OVMS_PIN_PLACEHOLDER = "nopin"
+
 # Lock command response parsing constants.
 # OVMS returns simple textual confirmations for lock/unlock commands.
 LOCK_COMMAND_ERROR_PREFIX = "Error: "

--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.6.3"
+  "version": "v1.6.4-beta1"
 }

--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.6.4-beta1"
+  "version": "v1.6.4-beta2"
 }

--- a/custom_components/ovms/mqtt/topic_parser.py
+++ b/custom_components/ovms/mqtt/topic_parser.py
@@ -329,17 +329,12 @@ class TopicParser:
         if self._should_be_binary_sensor(parts, metric_path):
             return "binary_sensor"
 
-        # Check for commands/switches
-        if "command" in parts or any(
-            switch_pattern in "_".join(parts).lower()
-            for switch_pattern in [
-                "switch",
-                "toggle",
-                "set",
-                "enable",
-                "disable",
-            ]
-        ):
+        # Check for commands/switches.
+        # Match parts exactly rather than as substrings; otherwise topic
+        # names like "cabinsetpoint" or "reset" would falsely match "set"
+        # and be created as switches instead of numeric sensors.
+        switch_keywords = {"switch", "toggle", "set", "enable", "disable"}
+        if "command" in parts or any(part.lower() in switch_keywords for part in parts):
             return "switch"
 
         # GPS metrics should be sensors

--- a/custom_components/ovms/sensor/switch.py
+++ b/custom_components/ovms/sensor/switch.py
@@ -12,8 +12,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from ..const import (
+    CONF_LOCK_PIN,
     DOMAIN,
+    LOCK_COMMAND_ERROR_PREFIX,
+    LOCK_COMMAND_USAGE_PREFIX,
     LOGGER_NAME,
+    OVMS_PIN_PLACEHOLDER,
+    PIN_SENSITIVE_COMMANDS,
     SWITCH_TYPES,
     SIGNAL_UPDATE_ENTITY,
     get_add_entities_signal,
@@ -25,7 +30,13 @@ from ..entity_state import (
     parse_boolean_state,
     update_attributes_from_json,
 )
-from ..utils import CommandFunction, get_entry_command_function
+from ..utils import (
+    CommandFunction,
+    get_entry_command_function,
+    get_merged_config,
+    is_secure_pin_connection,
+    normalize_lock_pin,
+)
 
 from ..metrics import get_metric_by_path, get_metric_by_pattern
 
@@ -39,6 +50,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up OVMS switches based on a config entry."""
     command_function = get_entry_command_function(hass, entry)
+    # Reuse the same stored lock PIN for PIN-sensitive switch commands
+    # (valet/unvalet). OVMS firmware uses one device PIN for all
+    # PIN-sensitive commands; gating on verified TLS mirrors the lock entity.
+    config = get_merged_config(entry)
+    default_lock_pin = normalize_lock_pin(config.get(CONF_LOCK_PIN))
+    pin_allowed = is_secure_pin_connection(config)
 
     @callback
     def async_add_switch(data: DiscoveryData) -> None:
@@ -63,6 +80,8 @@ async def async_setup_entry(
             hass=hass,
             friendly_name=data.get("friendly_name"),
             switch_config=switch_config,
+            default_pin=default_lock_pin,
+            pin_allowed=pin_allowed,
         )
 
         async_add_entities([switch])
@@ -93,6 +112,8 @@ class OVMSSwitch(SwitchEntity, RestoreEntity):
         hass: HomeAssistant | None = None,
         friendly_name: str | None = None,
         switch_config: dict[str, object] | None = None,
+        default_pin: str | None = None,
+        pin_allowed: bool = False,
     ) -> None:
         """Initialize the switch.
 
@@ -107,6 +128,10 @@ class OVMSSwitch(SwitchEntity, RestoreEntity):
             hass: Home Assistant instance
             friendly_name: User-friendly display name
             switch_config: Configuration for controllable metrics (on/off commands)
+            default_pin: Stored OVMS device PIN, appended to PIN-sensitive
+                commands (e.g. valet/unvalet) when present
+            pin_allowed: Whether the configured MQTT transport is verified TLS,
+                gating PIN usage to avoid sending it over plaintext
         """
         self._attr_unique_id = unique_id
         # Use the entity_id compatible name for internal use
@@ -127,6 +152,8 @@ class OVMSSwitch(SwitchEntity, RestoreEntity):
         self._command_function = command_function
         # Store switch configuration for controllable metrics
         self._switch_config = switch_config or {}
+        self._default_pin = normalize_lock_pin(default_pin)
+        self._pin_allowed = pin_allowed
 
         # Determine switch type and attributes
         self._determine_switch_type()
@@ -303,14 +330,37 @@ class OVMSSwitch(SwitchEntity, RestoreEntity):
 
         if self._switch_config.get(command_key):
             command = self._switch_config[command_key]
-            _LOGGER.debug(
-                "Turning %s switch: %s using configured command: %s",
-                command_type,
-                self.name,
-                command,
-            )
-            # Configured commands are complete (e.g., "charge start")
-            result = await self._command_function(command=command)
+            # PIN-sensitive commands (lock/unlock/valet/unvalet) need an
+            # argument because the OVMS firmware shell registers them with
+            # min/max=1 and rejects argument-less calls with "Usage: ...".
+            # Use the stored PIN when present (and only over verified TLS, to
+            # match the lock entity's gate); otherwise fall back to a neutral
+            # placeholder so the shell accepts the command. Vehicle modules
+            # that ignore the PIN value (e.g. Fiat 500e for valet) will
+            # execute the command; modules that validate the PIN will reject
+            # it cleanly and we surface that via _warn_if_command_failed.
+            pin_parameter = self._resolve_command_pin(command)
+            if pin_parameter is not None:
+                _LOGGER.debug(
+                    "Turning %s switch: %s using configured command: %s "
+                    "(PIN parameter appended)",
+                    command_type,
+                    self.name,
+                    command,
+                )
+                result = await self._command_function(
+                    command=command,
+                    parameters=pin_parameter,
+                )
+            else:
+                _LOGGER.debug(
+                    "Turning %s switch: %s using configured command: %s",
+                    command_type,
+                    self.name,
+                    command,
+                )
+                # Configured commands are complete (e.g., "charge start")
+                result = await self._command_function(command=command)
         else:
             # Fallback to legacy behavior with derived command + parameter
             command = self._derive_command()
@@ -327,6 +377,7 @@ class OVMSSwitch(SwitchEntity, RestoreEntity):
             )
 
         if result["success"]:
+            self._warn_if_command_failed(command, result.get("response"))
             self._attr_is_on = command_type == "on"
             self.async_write_ha_state()
         else:
@@ -336,6 +387,61 @@ class OVMSSwitch(SwitchEntity, RestoreEntity):
                 self.name,
                 result.get("error"),
             )
+
+    def _resolve_command_pin(self, command: str) -> str | None:
+        """Return the PIN argument to append to the command, or None.
+
+        For PIN-sensitive commands (lock/unlock/valet/unvalet) the OVMS shell
+        requires exactly one argument. Prefer the user's stored PIN when one
+        is configured over verified TLS; otherwise fall back to a neutral
+        placeholder so the shell still accepts the command. Non-PIN commands
+        (charge/climate) get no parameter from here.
+        """
+        if not command:
+            return None
+
+        first_token = command.split(maxsplit=1)[0].lower()
+        if first_token not in PIN_SENSITIVE_COMMANDS:
+            return None
+
+        if self._pin_allowed and self._default_pin:
+            return self._default_pin
+
+        return OVMS_PIN_PLACEHOLDER
+
+    def _warn_if_command_failed(self, command: str, response: object) -> None:
+        """Log a hint when OVMS reports a failure for a PIN-sensitive command.
+
+        OVMS replies with "Usage: ..." when a required argument is missing
+        (should not happen now that we always send a PIN argument) or with
+        "Error: ..." when the vehicle module rejected the command — most
+        commonly a PIN mismatch. The MQTT round-trip is still reported as
+        success, so the switch toggles optimistically; this warning is the
+        only signal a user gets that the vehicle ignored the command.
+        """
+        if not isinstance(response, str):
+            return
+
+        normalized = response.strip()
+        if not (
+            normalized.startswith(LOCK_COMMAND_USAGE_PREFIX)
+            or normalized.startswith(LOCK_COMMAND_ERROR_PREFIX)
+        ):
+            return
+
+        first_token = command.split(maxsplit=1)[0].lower() if command else ""
+        if first_token not in PIN_SENSITIVE_COMMANDS:
+            return
+
+        _LOGGER.warning(
+            "OVMS rejected '%s' on switch %s: %s. The vehicle module likely "
+            "requires a valid PIN. Configure a stored PIN over a verified "
+            "TLS connection (mqtts:// or wss://) in the integration options "
+            "to enable PIN-protected commands.",
+            command,
+            self.name,
+            normalized,
+        )
 
     async def async_turn_on(self, **kwargs: object) -> None:
         """Turn the switch on."""

--- a/custom_components/ovms/translations/en.json
+++ b/custom_components/ovms/translations/en.json
@@ -77,15 +77,15 @@
           "Port": "Connection Port",
           "verify_ssl_certificate": "Verify SSL/TLS Certificate",
           "topic_blacklist": "Topic Blacklist",
-          "lock_pin_mode": "Stored Lock PIN",
+          "lock_pin_mode": "Stored PIN",
           "lock_pin": "PIN Code",
           "entity_staleness_management": "Entity Staleness Management",
           "delete_stale_history": "Delete History"
         },
         "data_description": {
-          "verify_ssl_certificate": "SSL/TLS certificate verification only applies to secure ports (8883, 8084). Lock PIN support requires verified TLS.",
+          "verify_ssl_certificate": "SSL/TLS certificate verification only applies to secure ports (8883, 8084). Stored PIN support (for lock/unlock and valet/unvalet) requires verified TLS.",
           "topic_blacklist": "A comma-separated list of topic patterns to filter out. This prevents unwanted entities from being created. Any topic containing these patterns will be ignored. Use this to filter high-frequency log topics that create too many entities.",
-          "lock_pin": "Store your PIN here so you don't have to enter it every time you lock or unlock. Without a stored PIN, Home Assistant will prompt for one each time. Only available on verified secure MQTT connections.",
+          "lock_pin": "Store your OVMS device PIN here so you don't have to enter it every time you lock or unlock. The same stored PIN is also automatically used by the valet/unvalet switch. Without a stored PIN, Home Assistant will prompt for one when locking/unlocking; the valet switch will fall back to a neutral placeholder, which is enough for vehicles that don't validate the PIN (e.g. Fiat 500e). Only available on verified secure MQTT connections.",
           "entity_staleness_management": "Automatically hide inactive sensors after a period without updates to reduce UI clutter and improve performance",
           "delete_stale_history": "Delete history when hiding stale sensors (unchecked = hide only, preserves history)"
         }

--- a/custom_components/ovms/translations/strings.json
+++ b/custom_components/ovms/translations/strings.json
@@ -77,16 +77,16 @@
           "Port": "Connection Port",
           "verify_ssl_certificate": "Verify SSL/TLS Certificate",
           "topic_blacklist": "Topic Blacklist",
-          "lock_pin_mode": "Stored Lock PIN",
+          "lock_pin_mode": "Stored PIN",
           "lock_pin": "PIN Code",
           "entity_staleness_header": "Entity Staleness Management",
           "entity_staleness_management": "Entity Staleness Management",
           "delete_stale_history": "Delete History"
         },
         "data_description": {
-          "verify_ssl_certificate": "SSL/TLS certificate verification only applies to secure ports (8883, 8084). Lock PIN support requires verified TLS.",
+          "verify_ssl_certificate": "SSL/TLS certificate verification only applies to secure ports (8883, 8084). Stored PIN support (for lock/unlock and valet/unvalet) requires verified TLS.",
           "topic_blacklist": "A comma-separated list of topic patterns to filter out. This prevents unwanted entities from being created. Any topic containing these patterns will be ignored. Use this to filter high-frequency log topics that create too many entities.",
-          "lock_pin": "Store your PIN here so you don't have to enter it every time you lock or unlock. Without a stored PIN, Home Assistant will prompt for one each time. Only available on verified secure MQTT connections.",
+          "lock_pin": "Store your OVMS device PIN here so you don't have to enter it every time you lock or unlock. The same stored PIN is also automatically used by the valet/unvalet switch. Without a stored PIN, Home Assistant will prompt for one when locking/unlocking; the valet switch will fall back to a neutral placeholder, which is enough for vehicles that don't validate the PIN (e.g. Fiat 500e). Only available on verified secure MQTT connections.",
           "entity_staleness_header": "Automatically hide inactive sensors to reduce UI clutter",
           "entity_staleness_management": "Automatically hide inactive sensors after a period without updates to reduce UI clutter and improve performance",
           "delete_stale_history": "Delete history when hiding stale sensors (unchecked = hide only, preserves history)"


### PR DESCRIPTION
## Summary
- Topic parser used substring matching for switch trigger keywords (`switch`, `toggle`, `set`, `enable`, `disable`), causing `"set"` to match inside `"cabinsetpoint"`, `"reset"`, etc.
- This silently overrode the explicit `SensorDeviceClass.TEMPERATURE` on `v.e.cabinsetpoint`, creating it as a switch entity instead of a temperature sensor.
- Fix matches parts exactly rather than as substrings.

## Affected metrics
- `v.e.cabinsetpoint` → was switch, now temperature sensor (the reported bug)
- `xsq.use.at.reset` → was switch, now energy sensor (latent bug, same root cause)

## Whole-codebase audit
Cross-checked against all 941 metric names defined in the OVMS firmware repo. None of the 19 firmware metrics with underscored part names contain a trigger keyword as a sub-token, so an exact-part match handles every real OVMS topic correctly. Notification/event topics that contain trigger keywords (e.g. `xrt.sevcon.profile.switch`, `vehicle.type.set`) never reach `_determine_entity_type` because the `notify` and `event` families are blacklisted in `SYSTEM_TOPIC_BLACKLIST`. Real switches (HVAC, charging, valet) come from `SWITCH_TYPES` + `get_related_entities` and are unaffected by this change.

## Test plan
- [ ] After upgrading, the old `switch.*_cabin_temperature_setpoint` entity becomes orphaned (different unique_id since `_switch` suffix is dropped). Delete it manually in Home Assistant → Settings → Devices & services.
- [ ] A new `sensor.*_cabin_temperature_setpoint` is created with a temperature unit and numeric values.
- [ ] Existing HVAC, charging, and valet switches still work.
- [ ] (Smart ForTwo users only) `xsq.use.at.reset` now appears as an energy sensor.

Fixes #217