### PR TITLE
Fix #216: drop /client/ subtree at MQTT ingress to stop bogus entity discovery

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.6.3"
+  "version": "v1.6.4-beta3"
 }

--- a/custom_components/ovms/mqtt/__init__.py
+++ b/custom_components/ovms/mqtt/__init__.py
@@ -129,6 +129,28 @@ class OVMSMQTTClient:
         """Handle message received from MQTT broker."""
         self.message_count += 1
 
+        # Check if this is a command response and route it to the command handler
+        # This ensures command responses (client/rr/response/*) are properly
+        # routed to complete pending command futures instead of being treated
+        # as regular entity data. Done before the per-client filter below so
+        # our own responses still reach the handler.
+        if "client/rr/response" in topic:
+            _LOGGER.debug("Routing command response topic: %s", topic)
+            self.command_handler.process_response(topic, payload)
+            return
+
+        # Drop the rest of the /client/ subtree before any state is recorded.
+        # Other OVMS clients (the OVMS Connect mobile app, a second HA
+        # instance, shared-vehicle users) publish presence and per-client
+        # state under client/{their_client_id}/... — these are not vehicle
+        # metrics and must not pollute topic_cache, discovered_topics, the
+        # GPS-quality scan, or entity discovery. Filtering here also keeps
+        # the startup metric-request gate in _async_platforms_loaded honest:
+        # `if not self.discovered_topics` must only see real vehicle data.
+        # See issue #216.
+        if self.topic_parser.is_per_client_topic(topic):
+            return
+
         # Store in topic cache
         self.topic_cache[topic] = {
             "payload": payload,
@@ -137,15 +159,6 @@ class OVMSMQTTClient:
 
         # Add to discovered topics
         self.discovered_topics.add(topic)
-
-        # Check if this is a command response and route it to the command handler
-        # This ensures command responses (client/rr/response/*) are properly
-        # routed to complete pending command futures instead of being treated
-        # as regular entity data
-        if "client/rr/response" in topic:
-            _LOGGER.debug("Routing command response topic: %s", topic)
-            self.command_handler.process_response(topic, payload)
-            return
 
         # Track GPS quality topics for location accuracy
         if any(

--- a/custom_components/ovms/mqtt/topic_parser.py
+++ b/custom_components/ovms/mqtt/topic_parser.py
@@ -68,6 +68,28 @@ class TopicParser:
             vehicle_id = self.config.get("vehicle_id", "")
             return f"{prefix}/{vehicle_id}"
 
+    def is_per_client_topic(self, topic: str) -> bool:
+        """Return True if ``topic`` lives in the per-client subtree.
+
+        Per OVMS MQTT conventions the path after the structure prefix uses
+        ``client/`` for per-client state — commands, responses, requests, and
+        config queries. Other OVMS clients (mobile apps, second HA instances,
+        shared-vehicle users) publish under client/{their_client_id}/... and
+        must be excluded from entity discovery, cache, and dispatch. See
+        issue #216.
+        """
+        if topic.startswith(self.structure_prefix):
+            suffix = topic[len(self.structure_prefix) :].lstrip("/")
+        else:
+            vehicle_id = self.config.get("vehicle_id", "")
+            if not vehicle_id:
+                return False
+            marker = f"/{vehicle_id}/"
+            if marker not in topic:
+                return False
+            suffix = topic.split(marker, 1)[1]
+        return suffix.startswith("client/") or suffix == "client"
+
     def parse_topic(self, topic: str, payload: str) -> EntityData | None:
         """Parse a topic to determine the entity type and info."""
         try:
@@ -136,12 +158,14 @@ class TopicParser:
             if len(parts) < 2:
                 return None
 
-            # Check if this is a command/response/request topic - don't create entities for these
-            if (
-                "client/rr/command" in topic_suffix
-                or "client/rr/response" in topic_suffix
-                or "/request/" in topic_suffix
-            ):
+            # Skip the entire /client/ subtree - per OVMS MQTT conventions it is
+            # reserved for per-client state (commands at client/rr/command,
+            # responses at client/rr/response, and per-client request/config
+            # paths at client/{client_id}/...). Other OVMS clients (e.g. the
+            # OVMS Connect mobile app, a second HA instance, shared-vehicle
+            # users) publish under client/{their_client_id}/... and would
+            # otherwise be discovered as bogus entities. See issue #216.
+            if parts[0] == "client":
                 return None
 
             # Handle vendor-specific prefixes (like xvu, xsq, xmg, xnl)


### PR DESCRIPTION
## Summary

- Other OVMS clients sharing the same MQTT broker (OVMS Connect mobile app, second HA instance, shared-vehicle users) publish presence and per-client state under `<prefix>/<user>/<vehicle>/client/<their_client_id>/...`. The runtime only excluded the narrow `client/rr/command|response` and `/request/` paths, so everything else under `client/` leaked through and became phantom vehicle entities (issue #216).
- Adds an ingress-level filter in `_on_message_received` plus a shared `TopicParser.is_per_client_topic()` predicate. The command-response routing moves ahead of the cache writes so our own responses still reach the handler.
- Keeps the parser-level `parts[0] == "client"` check as defense in depth.
- No `CONFIG_VERSION` bump, no entity-registry migration — see release note below.

## Why ingress, not just the parser

`message_count`, `topic_cache`, and `discovered_topics` are populated in `_on_message_received` **before** the parser runs. A parser-only fix leaves them polluted with other-client topics, which also fooled the startup gate at `_async_platforms_loaded` (`if not self.discovered_topics`) into skipping the on-demand metric request even when zero vehicle metrics had arrived (latent secondary bug now fixed for free).

The same "/client/ is non-metric" intent already lived in `topic_discovery.py:506` from PR #207 ("echo filtering") but had never been propagated to the runtime path.

## 📣 Release note — for users hit by #216

If you have existing phantom entities created from other clients' topics before this fix (typically named like `..._client_<some_id>_active`), they will go **unavailable** after upgrade — the new filter stops their updates, but the entity-registry entries remain.

**To clean them up automatically**, enable the integration's built-in Entity Staleness Manager:

1. Settings → Devices & Services → OVMS → Configure
2. Set **Entity Staleness Management** to a number of hours (e.g. `24`)
3. Enable **Delete Stale History** to fully remove the entities (otherwise they are only hidden from the UI)

The staleness manager will then reap the phantom entities on its next sweep. After the cleanup you can disable the option again if you prefer.

Alternatively, delete the affected entities manually from Settings → Devices & Services → OVMS → Entities.

## Verification

- Verified against OVMS firmware MQTT conventions (openvehicles.com/node/2869): firmware never publishes under `client/`; it is strictly per-client namespace.
- No metric definition in `metrics/patterns.py`, `metrics/common/*.py`, or `metrics/vehicles/*.py` uses `client` as a path component.
- Smoke-tested the predicate across the default structure, the "Traditional" `{prefix}/client/{vehid}` structure (where `client` is part of the prefix, not the suffix), and the alt-username fallback path.
- `python3 scripts/tests/test_code_quality.py` passes.

## Test plan

- [ ] Confirm no new phantom entities appear when an OVMS Connect client (or any second client) is connected to the same broker
- [ ] Confirm command/response flow still works (`ovms.send_command` service round-trip)
- [ ] Confirm vehicle metrics under `v/`, `m/`, `s/`, vendor prefixes (`xvu`, `xnl`, …) still create entities
- [ ] Verify on a setup using the "Traditional" `{prefix}/client/{vehicle_id}` topic structure that vehicle metrics still discover correctly
- [ ] For users affected by #216: confirm the staleness-manager workflow above reaps the phantom entities

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)