### PR TITLE
Fix blocky/straight-line device_tracker GPS trail (#223)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,6 +204,11 @@ Release script:
 - Generates changelog from commits
 - Creates GitHub release with artifacts
 
+### Git & PR Conventions
+
+- **No AI attribution.** Do NOT add Claude Code / "Generated with" / "Co-authored-by: Claude" or any other AI-tool attribution to commit messages, PR descriptions, or issue comments. Write them in a normal contributor voice.
+- Keep commit messages focused on the change and its reasoning (reference issue numbers, e.g. `Fixes #223`).
+
 ## Integration Points
 
 ### MQTT Protocol

--- a/custom_components/ovms/const.py
+++ b/custom_components/ovms/const.py
@@ -348,6 +348,31 @@ MAX_STATE_LENGTH = 255
 GPS_ACCURACY_MIN_METERS = 5  # Minimum accuracy floor in meters
 GPS_ACCURACY_MAX_METERS = 100  # Maximum accuracy value (poorest quality)
 
+# GPS coordinate coalescing window (seconds)
+# OVMS publishes v.p.latitude and v.p.longitude as two SEPARATE MQTT messages,
+# emitted together within the same server transmission (typically <100 ms apart).
+# The device tracker needs both halves of a fix before it writes a position,
+# otherwise it either records a half-updated pair (new lat + stale lon = a
+# right-angle "blocky" artifact, issue #203) or, when only one axis changes
+# between fixes (e.g. driving due east only moves longitude), drops the update
+# entirely (sparse points joined by straight lines, issue #223).
+# We buffer incoming coordinates for this window and then emit the latest
+# lat/lon pair once. The window must be longer than the inter-message gap of a
+# single fix so the pair coalesces into one point, yet shorter than the GPS
+# publish interval when moving so consecutive fixes stay distinct.
+# 1.0 s sits comfortably above the ~100 ms intra-fix gap (with generous margin
+# for slow cellular links that could split the pair) and below the typical
+# >=1 s cellular MQTT location publish interval. Erring on the longer side is
+# deliberate: a merged point is invisible on the map, whereas a half-updated
+# pair is the exact right-angle artifact we are eliminating, and <=1 s of map
+# latency is irrelevant for a vehicle tracker.
+GPS_COALESCE_WINDOW = 1.0  # seconds
+
+# Minimum coordinate delta (degrees) before a position counts as moved.
+# 0.00001 deg ~= 1.1 m at the equator; smaller deltas are GPS jitter and would
+# only add redundant history points that make the map track look noisy.
+GPS_COORDINATE_DEADBAND = 0.00001
+
 
 def truncate_state_value(
     value: object, max_length: int = MAX_STATE_LENGTH

--- a/custom_components/ovms/device_tracker.py
+++ b/custom_components/ovms/device_tracker.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     DOMAIN,
+    GPS_COORDINATE_DEADBAND,
     LOGGER_NAME,
     SIGNAL_UPDATE_ENTITY,
     get_add_entities_signal,
@@ -236,8 +237,10 @@ class OVMSDeviceTracker(TrackerEntity, RestoreEntity):
                             if (
                                 self._prev_latitude is None
                                 or self._prev_longitude is None
-                                or abs(lat - self._prev_latitude) > 0.00001
-                                or abs(lon - self._prev_longitude) > 0.00001
+                                or abs(lat - self._prev_latitude)
+                                > GPS_COORDINATE_DEADBAND
+                                or abs(lon - self._prev_longitude)
+                                > GPS_COORDINATE_DEADBAND
                             ):
 
                                 coordinates_changed = True
@@ -267,7 +270,7 @@ class OVMSDeviceTracker(TrackerEntity, RestoreEntity):
                     if -90 <= lat <= 90:
                         if (
                             self._prev_latitude is None
-                            or abs(lat - self._prev_latitude) > 0.00001
+                            or abs(lat - self._prev_latitude) > GPS_COORDINATE_DEADBAND
                         ):
                             coordinates_changed = True
                             self._latitude = lat
@@ -286,7 +289,7 @@ class OVMSDeviceTracker(TrackerEntity, RestoreEntity):
                     if -180 <= lon <= 180:
                         if (
                             self._prev_longitude is None
-                            or abs(lon - self._prev_longitude) > 0.00001
+                            or abs(lon - self._prev_longitude) > GPS_COORDINATE_DEADBAND
                         ):
                             coordinates_changed = True
                             self._longitude = lon

--- a/custom_components/ovms/mqtt/__init__.py
+++ b/custom_components/ovms/mqtt/__init__.py
@@ -345,6 +345,10 @@ class OVMSMQTTClient:
         if hasattr(self, "staleness_manager"):
             await self.staleness_manager.async_shutdown()
 
+        # Cancel any pending GPS coalescing timer
+        if hasattr(self, "update_dispatcher"):
+            self.update_dispatcher.async_shutdown()
+
         await self.connection_manager.async_shutdown()
 
     def get_gps_accuracy(self, vehicle_id: Optional[str] = None) -> Optional[float]:

--- a/custom_components/ovms/mqtt/update_dispatcher.py
+++ b/custom_components/ovms/mqtt/update_dispatcher.py
@@ -1,17 +1,16 @@
 """Update dispatcher for OVMS integration."""
 
 import logging
-import time
-from typing import Any, Dict, Optional, Set, List
+from typing import Any, Dict, Optional
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.util import dt as dt_util
 
 from ..const import (
     CONF_CLIENT_ID,
     CONF_CONFIG_ENTRY_ID,
     CONF_VEHICLE_ID,
+    GPS_COALESCE_WINDOW,
     LOGGER_NAME,
     SIGNAL_UPDATE_ENTITY,
     DOMAIN,
@@ -36,13 +35,12 @@ class UpdateDispatcher:
         self.hass = hass
         self.entity_registry = entity_registry
         self.attribute_manager = attribute_manager
-        self.last_location_update = {}  # Track when location was last updated
         self.location_values = {}  # Store current location values
-        self._coordinate_generation = {"latitude": 0, "longitude": 0}
-        self._last_dispatched_coordinate_generation = {
-            "latitude": 0,
-            "longitude": 0,
-        }
+        # Pending one-shot timer that flushes a coalesced lat/lon pair. OVMS
+        # publishes latitude and longitude as two separate messages; we buffer
+        # them for GPS_COALESCE_WINDOW so the tracker writes one consistent
+        # position instead of a half-updated pair. See issues #203 and #223.
+        self._location_flush_handle = None
         self._config = config or {}
         self._device_identifier = get_ovms_device_identifier(
             self._config.get(CONF_CLIENT_ID),
@@ -167,8 +165,6 @@ class UpdateDispatcher:
     def _handle_location_update(self, topic: str, entity_id: str, payload: Any) -> None:
         """Handle updates to location topics."""
         try:
-            now = dt_util.utcnow().timestamp()
-
             # Extract latitude/longitude values if applicable
             is_latitude = any(
                 keyword in topic.lower() for keyword in ["latitude", "lat"]
@@ -187,26 +183,58 @@ class UpdateDispatcher:
                 )
                 return
 
-            # Update our location values cache
+            # Update our location values cache. We do NOT push to the device
+            # tracker yet: latitude and longitude arrive as two separate
+            # messages, so emitting now would write a half-updated pair (new
+            # latitude + stale longitude) - the right-angle artifact from
+            # issue #203. Instead we buffer briefly and flush the latest pair.
             if is_latitude:
                 self.location_values["latitude"] = coordinate
-                self.last_location_update["latitude"] = now
-                self._coordinate_generation["latitude"] += 1
             elif is_longitude:
                 self.location_values["longitude"] = coordinate
-                self.last_location_update["longitude"] = now
-                self._coordinate_generation["longitude"] += 1
 
-            # Only update device trackers if we have both latitude and longitude
-            if (
-                "latitude" in self.location_values
-                and "longitude" in self.location_values
-                and self._has_fresh_coordinate_pair()
-            ):
-                self._update_all_device_trackers()
+            self._schedule_location_flush()
 
         except Exception as ex:
             _LOGGER.exception("Error handling location update: %s", ex)
+
+    def _schedule_location_flush(self) -> None:
+        """Schedule a one-shot flush of the buffered lat/lon pair.
+
+        Coalesces the separate latitude and longitude messages of a single GPS
+        fix into one device-tracker update. A flush is scheduled at most once
+        per GPS_COALESCE_WINDOW; coordinates arriving inside the window simply
+        refresh location_values so the flush always emits the most recent pair.
+        This both prevents half-updated pairs (issue #203) and stops single-axis
+        movement from being dropped (issue #223), since the flush fires on any
+        coordinate change rather than requiring both axes to change.
+        """
+        if self._location_flush_handle is not None:
+            return
+
+        loop = getattr(self.hass, "loop", None)
+        if loop is None:
+            # No event loop available (should not happen in production); emit
+            # immediately so behaviour degrades gracefully instead of stalling.
+            self._flush_location()
+            return
+
+        self._location_flush_handle = loop.call_later(
+            GPS_COALESCE_WINDOW, self._flush_location
+        )
+
+    @callback
+    def _flush_location(self) -> None:
+        """Emit the buffered lat/lon pair to the device trackers."""
+        self._location_flush_handle = None
+        if "latitude" in self.location_values and "longitude" in self.location_values:
+            self._update_all_device_trackers()
+
+    def async_shutdown(self) -> None:
+        """Cancel any pending location flush on teardown."""
+        if self._location_flush_handle is not None:
+            self._location_flush_handle.cancel()
+            self._location_flush_handle = None
 
     def _handle_version_update(self, topic: str, entity_id: str, payload: str) -> None:
         """Handle updates to version topics with special priority."""
@@ -399,18 +427,5 @@ class UpdateDispatcher:
                 if topic == "combined_location":
                     self._update_entity(tracker_id, payload)
 
-            self._last_dispatched_coordinate_generation = (
-                self._coordinate_generation.copy()
-            )
-
         except Exception as ex:
             _LOGGER.exception("Error updating device trackers: %s", ex)
-
-    def _has_fresh_coordinate_pair(self) -> bool:
-        """Return True when both coordinates have arrived since the last dispatch."""
-        return (
-            self._coordinate_generation["latitude"]
-            > self._last_dispatched_coordinate_generation["latitude"]
-            and self._coordinate_generation["longitude"]
-            > self._last_dispatched_coordinate_generation["longitude"]
-        )

--- a/scripts/tests/test_device_tracker_gps.py
+++ b/scripts/tests/test_device_tracker_gps.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Regression test for the OVMS device-tracker GPS coalescing.
+
+OVMS publishes ``v.p.latitude`` and ``v.p.longitude`` as two SEPARATE MQTT
+messages. The combined device tracker must assemble them into one position
+without:
+
+  * dropping single-axis movement -- driving due east only moves longitude, so
+    a tracker that waits for BOTH axes to change records nothing and the map
+    draws a straight line between far-apart points (issue #223); and
+  * recording a half-updated pair -- new latitude paired with stale longitude
+    produces a right-angle "blocky" artifact (issue #203).
+
+This test drives the REAL UpdateDispatcher + OVMSDeviceTracker with simulated
+GPS message streams and asserts the tracker writes exactly the correct
+positions. A deterministic fake event loop fires the coalescing timer between
+fixes (real fixes arrive >= 1 s apart, well past GPS_COALESCE_WINDOW).
+
+Run standalone:  python3 scripts/tests/test_device_tracker_gps.py
+Exits non-zero on failure so CI catches regressions of #203 / #223.
+"""
+
+import asyncio
+import os
+import sys
+
+# Make the repo root importable when run directly from scripts/tests/.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import custom_components.ovms.mqtt.update_dispatcher as ud_mod
+import custom_components.ovms.mqtt.entity_factory as ef_mod
+import custom_components.ovms.device_tracker as dt_mod
+
+from custom_components.ovms.mqtt.topic_parser import TopicParser
+from custom_components.ovms.mqtt.entity_registry import EntityRegistry
+from custom_components.ovms.mqtt.update_dispatcher import UpdateDispatcher
+from custom_components.ovms.mqtt.entity_factory import EntityFactory
+from custom_components.ovms.device_tracker import OVMSDeviceTracker
+from custom_components.ovms.naming_service import EntityNamingService
+from custom_components.ovms.attribute_manager import AttributeManager
+from custom_components.ovms.const import GPS_COALESCE_WINDOW, get_add_entities_signal
+
+ENTRY_ID = "entry1"
+CONFIG = {
+    "vehicle_id": "leaf",
+    "topic_prefix": "ovms",
+    "mqtt_username": "user",
+    "topic_structure": "{prefix}/{mqtt_username}/{vehicle_id}",
+    "client_id": "ha_ovms_abc123",
+    "config_entry_id": ENTRY_ID,
+}
+LAT_TOPIC = "ovms/user/leaf/metric/v/p/latitude"
+LON_TOPIC = "ovms/user/leaf/metric/v/p/longitude"
+
+# In-process replacement for the HA dispatcher transport.
+_BUS = {}
+
+
+def _connect(_hass, signal, target):
+    _BUS.setdefault(signal, []).append(target)
+    return lambda: None
+
+
+def _send(_hass, signal, *args):
+    for target in list(_BUS.get(signal, [])):
+        target(*args)
+
+
+ud_mod.async_dispatcher_send = _send
+ef_mod.async_dispatcher_send = _send
+dt_mod.async_dispatcher_connect = _connect
+
+
+class _FakeTimer:
+    """Cancelable handle returned by the fake loop's call_later."""
+
+    def __init__(self, when, callback):
+        self.when = when
+        self.callback = callback
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class _FakeLoop:
+    """Minimal call_later scheduler driven by an explicit clock."""
+
+    def __init__(self):
+        self.now = 0.0
+        self.timers = []
+
+    def call_later(self, delay, callback, *args):
+        timer = _FakeTimer(self.now + delay, lambda: callback(*args))
+        self.timers.append(timer)
+        return timer
+
+    def advance(self, seconds):
+        target = self.now + seconds
+        while True:
+            due = [t for t in self.timers if not t.cancelled and t.when <= target]
+            if not due:
+                break
+            due.sort(key=lambda t: t.when)
+            timer = due[0]
+            self.now = timer.when
+            self.timers.remove(timer)
+            timer.callback()
+        self.now = target
+
+
+class _FakeHass:
+    def __init__(self):
+        self.data = {"ovms": {"dispatched_updates": set()}}
+        self.loop = _FakeLoop()
+
+
+class _RecordingTracker(OVMSDeviceTracker):
+    """Tracker that records the positions it would write to HA history."""
+
+    def __init__(self, *args, writes, **kwargs):
+        self._writes = writes
+        super().__init__(*args, **kwargs)
+
+    async def async_get_last_state(self):
+        return None
+
+    def async_write_ha_state(self):
+        self._writes.append((round(self._latitude, 6), round(self._longitude, 6)))
+
+
+async def _build():
+    _BUS.clear()
+    writes = []
+    hass = _FakeHass()
+    registry = EntityRegistry()
+    attr = AttributeManager(CONFIG)
+    naming = EntityNamingService(CONFIG)
+    dispatcher = UpdateDispatcher(hass, registry, attr, CONFIG)
+    factory = EntityFactory(hass, registry, dispatcher, CONFIG, naming, attr)
+    factory.platforms_loaded = True
+    parser = TopicParser(CONFIG, registry)
+
+    holder = {}
+
+    def on_add(data):
+        if data.get("entity_type") == "device_tracker":
+            holder["data"] = data
+
+    _BUS.setdefault(get_add_entities_signal(ENTRY_ID), []).append(on_add)
+    for topic, value in ((LAT_TOPIC, "59.1"), (LON_TOPIC, "10.1")):
+        await factory.async_create_entities(
+            topic, value, parser.parse_topic(topic, value)
+        )
+
+    data = holder["data"]
+    tracker = _RecordingTracker(
+        data["unique_id"],
+        data["name"],
+        data["topic"],
+        data["payload"],
+        data["device_info"],
+        data["attributes"],
+        hass,
+        data["friendly_name"],
+        naming,
+        attr,
+        writes=writes,
+    )
+    await tracker.async_added_to_hass()
+    return hass, dispatcher, writes
+
+
+async def _run(ticks):
+    """Feed per-fix message groups; advance the clock past the coalesce window
+    between fixes. Returns the list of positions the tracker recorded."""
+    hass, dispatcher, writes = await _build()
+    for tick in ticks:
+        for kind, value in tick:
+            topic = LAT_TOPIC if kind == "lat" else LON_TOPIC
+            dispatcher.dispatch_update(topic, f"{value:.6f}")
+        hass.loop.advance(GPS_COALESCE_WINDOW + 0.1)
+    return writes
+
+
+def _expected(ticks):
+    """Best-known position after each fix = (latest lat, latest lon), deduped."""
+    out = []
+    lat = lon = None
+    for tick in ticks:
+        for kind, value in tick:
+            if kind == "lat":
+                lat = round(value, 6)
+            else:
+                lon = round(value, 6)
+        if lat is not None and lon is not None and (not out or out[-1] != (lat, lon)):
+            out.append((lat, lon))
+    return out
+
+
+def _check(name, ticks, results):
+    written = asyncio.run(_run(ticks))
+    expected = _expected(ticks)
+    expected_set = set(expected)
+    dropped = [p for p in expected if p not in set(written)]
+    stale_mix = [p for p in written if p not in expected_set]
+    ok = not dropped and not stale_mix
+    results.append(ok)
+    print(f"  {'PASS' if ok else 'FAIL'}  {name}")
+    print(f"        expected {len(expected)} positions, tracker wrote {len(written)}")
+    if dropped:
+        print(f"        DROPPED (issue #223 straight lines): {dropped}")
+    if stale_mix:
+        print(f"        STALE-MIX (issue #203 blocky): {stale_mix}")
+
+
+def main():
+    print("OVMS device-tracker GPS coalescing regression test")
+    print("-" * 55)
+    results = []
+
+    # Normal drive: latitude then longitude per fix.
+    _check(
+        "alternating lat,lon per fix",
+        [[("lat", 59.100 + i * 0.001), ("lon", 10.100 + i * 0.001)] for i in range(5)],
+        results,
+    )
+
+    # Reversed order: longitude then latitude per fix.
+    _check(
+        "lon-then-lat per fix",
+        [[("lon", 10.100 + i * 0.001), ("lat", 59.100 + i * 0.001)] for i in range(5)],
+        results,
+    )
+
+    # Drive due east: latitude static, only longitude changes (issue #223).
+    _check(
+        "drive east, latitude static (single-axis)",
+        [[("lat", 59.100), ("lon", 10.100)]]
+        + [[("lon", 10.100 + i * 0.001)] for i in range(1, 5)],
+        results,
+    )
+
+    # Retained-message burst on reconnect: all lat then all lon in one window.
+    _check(
+        "burst redelivery (all lat, then all lon)",
+        [
+            [("lat", 59.100 + i * 0.001) for i in range(4)]
+            + [("lon", 10.100 + i * 0.001) for i in range(4)]
+        ],
+        results,
+    )
+
+    # Latitude updating faster than longitude near a turn.
+    _check(
+        "latitude faster than longitude (turn)",
+        [
+            [("lat", 59.100), ("lon", 10.100)],
+            [("lat", 59.101)],
+            [("lat", 59.102), ("lon", 10.101)],
+            [("lat", 59.103), ("lon", 10.102)],
+            [("lon", 10.103)],
+        ],
+        results,
+    )
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} scenarios passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} scenarios FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

`device_tracker` location history renders as right-angle "blocky" steps or long straight-line jumps instead of a smooth track (#223, follow-up to #203).

<img width="1280" height="1004" alt="image" src="https://github.com/user-attachments/assets/1c3e7ae7-b1f9-4f8b-97e4-51ef68692f8f" />


## Root cause

OVMS publishes `v.p.latitude` and `v.p.longitude` as **two separate MQTT messages**. The combined device tracker assembles them into one position. The previous gate in `update_dispatcher.py` (`_has_fresh_coordinate_pair`) only emitted a position when **both** axes had changed since the last emit. Real driving breaks this:

- **Driving along a cardinal direction** moves essentially one axis per fix (e.g. heading east → only longitude changes beyond OVMS's ~1 m deadband). The gate kept waiting for the other axis, so those fixes were **dropped** → the map connects far-apart points with straight lines (#223).
- **Per-axis message bursts** (e.g. retained-message redelivery on reconnect) could emit a **half-updated pair** — new latitude with stale longitude — → the right-angle artifact (#203).

I reproduced both failure modes by driving simulated message streams through the real `TopicParser → EntityFactory → EntityRegistry → UpdateDispatcher → OVMSDeviceTracker` path and recording exactly the coordinates the tracker would write to history.

## Fix

Replace the brittle "both axes fresh" gate with a short **coalescing window** (`GPS_COALESCE_WINDOW`, 1.0 s): buffer incoming coordinates and flush the **latest lat/lon pair together** once per window. lat+lon of one fix (arriving ms apart) merge into one consistent point; a single-axis change still emits with the latest pair. Result: every fix is recorded with a current, consistent position — no dropped fixes, no half-updated pairs.

Also:
- Move the hardcoded `0.00001` coordinate deadband into `const.py` (`GPS_COORDINATE_DEADBAND`).
- Remove the now-dead generation bookkeeping and unused imports.
- Cancel the pending coalesce timer on shutdown.

## Tests / validation

- New `scripts/tests/test_device_tracker_gps.py` drives the real dispatcher + tracker through the message patterns that reproduced the bug (alternating, single-axis "drive east", reconnect burst, axis-rate-mismatch) and asserts **zero dropped positions** and **zero stale-mix points**. It fails on the old code and passes on this change.
- On the same realistic curved route, the old gate dropped 9 of 60 fixes; this change records all 60.
- Validated end-to-end in a live Home Assistant + Mosquitto instance: replayed a **200 km drive through Sweden** (E4, Stockholm→Mantorp) over MQTT — all **97/97 GPS fixes** recorded as distinct positions, 0 right-angle segments, smooth trail on the map.

Existing quality gates pass (black, pylint 0 errors, `scripts/tests/test_code_quality.py`).

Fixes #223