### PR TITLE
Add Smart ForTwo HV contactor cycles counter (#224)

### DIFF
--- a/custom_components/ovms/metrics/vehicles/smart_fortwo.py
+++ b/custom_components/ovms/metrics/vehicles/smart_fortwo.py
@@ -27,6 +27,18 @@ METRIC_PREFIX = "xse."
 
 # Smart ForTwo specific metrics
 SMART_FORTWO_METRICS = {
+    "xsq.12v.trickle.count": {
+        "name": "Smart ForTwo 12V Trickle Charge Cycles 24h",
+        "description": (
+            "Number of 12V battery trickle-charge cycles in the last 24 hours "
+            "(Smart 453). Frequent trickle charging can indicate a weak 12V "
+            "battery. Requires OVMS firmware 3.3.006+."
+        ),
+        "icon": "mdi:battery-clock",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": "cycles",
+        "category": "smart_fortwo",
+    },
     "xsq.bms.amp2": {
         "name": "Smart ForTwo BMS Amp2",
         "description": "BMS secondary amp measurement",
@@ -92,6 +104,26 @@ SMART_FORTWO_METRICS = {
         "unit": UnitOfElectricPotential.VOLT,
         "suggested_display_precision": 2,
         "category": "smart_fortwo",
+    },
+    "xsq.bms.contactor.cycles": {
+        "name": "Smart ForTwo HV Contactor Cycles Remaining",
+        "description": (
+            "Remaining HV battery contactor switching cycles on Smart 453. "
+            "The BMS counts down from 200000; reaching 0 leaves the car "
+            "undriveable, and a sudden large drop can signal the contactor "
+            "counter glitch. OVMS publishes xsq.bms.contactor.cycles as a "
+            "vector [max, now, consumed, diff, cycles_last_hour]; 'now' is the "
+            "remaining count and the others are exposed as attributes. "
+            "Requires OVMS firmware 3.3.006+ (see 'xsq hvcycles')."
+        ),
+        "icon": "mdi:counter",
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": "cycles",
+        "category": "smart_fortwo",
+        # Heterogeneous vector: handled by the sensor's config-driven vector
+        # path so the state is the remaining count, not the mean of all five.
+        "vector_attributes": ["max", "now", "consumed", "diff", "cycles_last_hour"],
+        "vector_state": "now",
     },
     "xsq.bms.cv.range.max": {
         "name": "Smart ForTwo Cell Voltage Max",

--- a/custom_components/ovms/sensor/entities.py
+++ b/custom_components/ovms/sensor/entities.py
@@ -25,6 +25,7 @@ from ..const import (
 )
 from .parsers import (
     parse_value,
+    parse_labeled_vector,
     process_json_payload,
     requires_numeric_value,
     is_special_state_value,
@@ -490,19 +491,20 @@ class OVMSSensor(SensorEntity, RestoreEntity):
             self._attr_extra_state_attributes.get("original_state_class")
             or self._attr_state_class
         )
-        self._parsed_value = parse_value(
-            initial_state,
-            device_class_for_parsing,
-            state_class_for_parsing,
-            self._is_cell_sensor,
-        )
+        if not self._try_parse_vector(initial_state):
+            self._parsed_value = parse_value(
+                initial_state,
+                device_class_for_parsing,
+                state_class_for_parsing,
+                self._is_cell_sensor,
+            )
 
-        # Format the value
-        self._attr_native_value = format_sensor_value(
-            self._parsed_value,
-            device_class_for_parsing,
-            self._attr_extra_state_attributes,
-        )
+            # Format the value
+            self._attr_native_value = format_sensor_value(
+                self._parsed_value,
+                device_class_for_parsing,
+                self._attr_extra_state_attributes,
+            )
 
         # Extract additional attributes
         if (
@@ -637,6 +639,13 @@ class OVMSSensor(SensorEntity, RestoreEntity):
                 or self._attr_state_class
             )
 
+            # Fixed-position vector metrics (e.g. contactor cycles) carry a
+            # distinct meaning per element; handle them before the generic
+            # comma-averaging so the state is the chosen element, not a mean.
+            if self._try_parse_vector(payload):
+                self.async_write_ha_state()
+                return
+
             self._parsed_value = parse_value(
                 payload,
                 device_class_for_parsing,
@@ -683,6 +692,32 @@ class OVMSSensor(SensorEntity, RestoreEntity):
                     update_state,
                 )
             )
+
+    def _try_parse_vector(self, payload: Any) -> bool:
+        """Apply config-driven vector handling if the metric declares it.
+
+        A metric definition can declare ``vector_attributes`` (ordered labels,
+        one per CSV position) and ``vector_state`` (the label whose value is the
+        sensor state). When present and the payload is a usable CSV vector, the
+        chosen element becomes the native value and every labelled element is
+        exposed as an attribute. Returns True when it handled the payload, so
+        the caller skips the default comma-averaging. No-op (returns False) for
+        every metric that doesn't declare a vector, so existing sensors are
+        unaffected. See OVMS metric xsq.bms.contactor.cycles and issue #224.
+        """
+        labels = self._attr_extra_state_attributes.get("vector_attributes")
+        state_label = self._attr_extra_state_attributes.get("vector_state")
+        if not labels or not state_label:
+            return False
+
+        state_value, vector_attrs = parse_labeled_vector(payload, labels, state_label)
+        if state_value is None:
+            return False
+
+        self._parsed_value = state_value
+        self._attr_native_value = state_value
+        self._attr_extra_state_attributes.update(vector_attrs)
+        return True
 
     def _handle_cell_values(self, payload: str) -> None:
         """Handle cell values in payload."""

--- a/custom_components/ovms/sensor/parsers.py
+++ b/custom_components/ovms/sensor/parsers.py
@@ -75,6 +75,46 @@ def calculate_median(values: List[float]) -> Optional[float]:
     return sorted_values[n // 2]
 
 
+def parse_labeled_vector(
+    payload: Any, labels: List[str], state_label: str
+) -> tuple[Optional[Any], Dict[str, Any]]:
+    """Parse a fixed-position CSV vector into a state value and named attributes.
+
+    Some OVMS metrics are published as comma-separated vectors where each
+    position has a distinct meaning rather than being a sample of the same
+    quantity - e.g. ``xsq.bms.contactor.cycles`` is
+    ``[max, now, consumed, diff, cycles_last_hour]``. Averaging such a vector
+    (the default comma handling) is meaningless, so a metric definition can
+    declare ``vector_attributes`` (the ordered position labels) and
+    ``vector_state`` (the label whose value is the sensor's main state). This
+    maps each position to its label and returns the chosen element as the state.
+
+    Args:
+        payload: Comma-separated values from the metric topic.
+        labels: Ordered labels, one per vector position.
+        state_label: The label whose value becomes the sensor state.
+
+    Returns:
+        Tuple of (state_value, {label: value}). state_value is None and the
+        dict is empty when the payload is not a usable CSV vector.
+    """
+    if not isinstance(payload, str) or "," not in payload:
+        return None, {}
+
+    parts = [p.strip() for p in payload.split(",")]
+    attributes: Dict[str, Any] = {}
+    for index, label in enumerate(labels):
+        if index >= len(parts) or parts[index] == "":
+            continue
+        try:
+            number = float(parts[index])
+            attributes[label] = int(number) if number.is_integer() else number
+        except ValueError:
+            attributes[label] = parts[index]
+
+    return attributes.get(state_label), attributes
+
+
 def parse_comma_separated_values(
     value: str,
     entity_name: str = "",

--- a/scripts/tests/test_contactor_cycles.py
+++ b/scripts/tests/test_contactor_cycles.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Regression test for the Smart ForTwo HV contactor cycles sensor (#224).
+
+OVMS publishes ``xsq.bms.contactor.cycles`` as a fixed-position CSV vector
+``[max, now, consumed, diff, cycles_last_hour]`` where the meaningful counter
+is ``now`` (remaining cycles, counts down from 200000). The default comma
+handling would average all five heterogeneous elements, which is meaningless.
+
+The metric declares ``vector_attributes`` + ``vector_state`` and the sensor's
+config-driven vector path turns that into: state = ``now``, with every element
+exposed as a named attribute. This test drives the REAL OVMSSensor through an
+initial value and live updates and asserts that, plus that an ordinary metric
+(no vector config) is unaffected.
+
+Run standalone:  python3 scripts/tests/test_contactor_cycles.py
+Exits non-zero on failure.
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import custom_components.ovms.sensor.entities as entities_mod
+
+from custom_components.ovms.sensor.entities import OVMSSensor
+from custom_components.ovms.attribute_manager import AttributeManager
+from custom_components.ovms.metrics import get_metric_by_path
+from custom_components.ovms.const import SIGNAL_UPDATE_ENTITY
+
+CONTACTOR_TOPIC = "ovms/u/sq/metric/xsq/bms/contactor/cycles"
+CONTACTOR_PATH = "xsq.bms.contactor.cycles"
+# An ordinary scalar metric (no vector config) - must be unaffected.
+PLAIN_TOPIC = "ovms/u/sq/metric/xsq/bms/amps"
+PLAIN_PATH = "xsq.bms.amps"
+
+_BUS = {}
+
+
+def _connect(_hass, signal, target):
+    _BUS.setdefault(signal, []).append(target)
+    return lambda: None
+
+
+def _send(signal, payload):
+    for target in list(_BUS.get(signal, [])):
+        target(payload)
+
+
+entities_mod.async_dispatcher_connect = _connect
+
+
+class _FakeHass:
+    def __init__(self):
+        self.data = {}
+        self.loop = None
+
+
+class _TestSensor(OVMSSensor):
+    async def async_get_last_state(self):
+        return None
+
+    def async_write_ha_state(self):
+        pass
+
+
+def _build(path, topic, initial_state):
+    attr_mgr = AttributeManager({})
+    metric = get_metric_by_path(path)
+    assert metric is not None, f"metric {path} not found"
+    parts = topic.split("/")[3:]
+    attributes = attr_mgr.prepare_attributes(
+        topic, metric.get("category", "unknown"), parts, metric
+    )
+    sensor = _TestSensor(
+        unique_id=f"ovms_test_{path.replace('.', '_')}",
+        name=f"ovms_{path.replace('.', '_')}",
+        topic=topic,
+        initial_state=initial_state,
+        device_info={},
+        attributes=attributes,
+        friendly_name=metric.get("name"),
+        hass=_FakeHass(),
+    )
+    return sensor, attributes
+
+
+def _check(name, cond, results):
+    results.append(cond)
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+
+async def main():
+    print("OVMS contactor-cycles vector sensor regression test")
+    print("-" * 55)
+    results = []
+
+    # ---- contactor cycles: initial retained value ----
+    _BUS.clear()
+    sensor, attrs = _build(CONTACTOR_PATH, CONTACTOR_TOPIC, "200000,198500,1500,0,3")
+    await sensor.async_added_to_hass()
+    _check(
+        "metric declares vector config",
+        attrs.get("vector_state") == "now"
+        and attrs.get("vector_attributes")[1] == "now",
+        results,
+    )
+    _check(
+        "initial state = remaining 'now' (198500), not the mean",
+        sensor.native_value == 198500,
+        results,
+    )
+    a = sensor.extra_state_attributes
+    _check(
+        "named attributes present",
+        a.get("max") == 200000
+        and a.get("consumed") == 1500
+        and a.get("diff") == 0
+        and a.get("cycles_last_hour") == 3,
+        results,
+    )
+
+    # ---- a live update reflecting cycles being consumed ----
+    _send(f"{SIGNAL_UPDATE_ENTITY}_{sensor.unique_id}", "200000,198400,1600,100,5")
+    _check(
+        "update tracks the new remaining count (198400)",
+        sensor.native_value == 198400,
+        results,
+    )
+    _check(
+        "update refreshes named attributes (diff=100, last_hour=5)",
+        sensor.extra_state_attributes.get("diff") == 100
+        and sensor.extra_state_attributes.get("cycles_last_hour") == 5,
+        results,
+    )
+
+    # ---- no regression: an ordinary metric is untouched and the vector
+    #      gate is inert when the metric declares no vector config ----
+    _BUS.clear()
+    plain, _ = _build(PLAIN_PATH, PLAIN_TOPIC, "12.5")
+    await plain.async_added_to_hass()
+    _check(
+        "ordinary scalar metric unaffected (12.5)", plain.native_value == 12.5, results
+    )
+    _check(
+        "vector gate is inert without vector config (returns False)",
+        plain._try_parse_vector("1,2,3") is False,
+        results,
+    )
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## What

Adds the Smart EQ/ForTwo (Smart 453) **HV battery contactor switching cycle counter** requested in #224, available from OVMS firmware 3.3.006 via `xsq.bms.contactor.cycles`.

The Smart 453 BMS counts the HV contactor down from 200,000 remaining cycles; reaching 0 leaves the car undriveable, and a sudden large drop can indicate the known contactor-counter glitch. OVMS 3.3.006 added monitoring for this.

## The catch

`xsq.bms.contactor.cycles` is **not a scalar** — it's a fixed-position vector `[max, now, consumed, diff, cycles_last_hour]`. The meaningful counter is `now` (remaining cycles). The integration's default comma handling averages CSV values, which for these five heterogeneous elements is meaningless (mean ≈ 80000).

## How

A small, **config-driven vector path** in the sensor entity: a metric definition may declare `vector_attributes` (ordered position labels) and `vector_state` (the label whose value becomes the sensor state). When present and the payload is a CSV vector, the chosen element becomes the native value and each element is exposed as a named attribute. The path is **inert for every metric that doesn't declare a vector**, so existing sensors are completely unaffected (verified in the test).

Metrics added to `metrics/vehicles/smart_fortwo.py`:
- `xsq.bms.contactor.cycles` → state = remaining `now`; attributes `max`, `now`, `consumed`, `diff`, `cycles_last_hour`.
- `xsq.12v.trickle.count` → 12V trickle-charge cycles in 24h (companion counter, also new in 3.3.006).

## Scope notes

- This is **Smart ForTwo only** (`xsq.*` is the Smart 453 module prefix; the counter glitch is specific to that HV battery).
- Firmware 3.3.006 also added a batch of **VW e-Up** battery-aging metrics (`xvu.b.time.*`, incl. a 6×8 park-time matrix) — different vehicle, left for a separate PR.

## Tests / validation

- New `scripts/tests/test_contactor_cycles.py` drives the **real `OVMSSensor`**: asserts state = remaining `now` (not the mean), the named attributes, that live updates track the remaining count, and that an ordinary metric / the vector gate are unaffected. 7/7 checks pass.
- Validated end-to-end in a live Home Assistant: added a simulated Smart ForTwo over MQTT and confirmed the sensor reads **198,500 cycles** with attributes `max=200000, now=198500, consumed=1500, diff=0, cycles_last_hour=3`, plus the 12V trickle counter.

Existing quality gates pass (black, pylint aggregate `--fail-under=9.0`, `scripts/tests/test_code_quality.py`).

Fixes #224