### PR TITLE
Add VW e-Up battery aging metrics (OVMS 3.3.006)

### DIFF
--- a/custom_components/ovms/const.py
+++ b/custom_components/ovms/const.py
@@ -152,6 +152,10 @@ SYSTEM_TOPIC_BLACKLIST = [
     "server/web/socket",
     "egpio/output",
     "power/can1",
+    # VW e-Up 6x8 SOC/temperature park-time matrix (OVMS 3.3.006): a 48-value
+    # vector with no meaningful single sensor state (>255 char raw value); its
+    # useful aggregates are exposed as the xvu.b.time.* scalars instead.
+    "xvu/b/time/parked/state",
 ]
 
 # Legacy topic blacklist patterns - kept for migration compatibility

--- a/custom_components/ovms/metrics/vehicles/vw_eup.py
+++ b/custom_components/ovms/metrics/vehicles/vw_eup.py
@@ -131,8 +131,9 @@ VW_EUP_METRICS = {
         "category": "vw_eup",
     },
     # Battery health / aging counters, new in OVMS firmware 3.3.006. These are
-    # cumulative lifetime totals (the BMS only ever increases them) whose value
-    # is meant to be trended, so they are TOTAL_INCREASING with a time unit.
+    # cumulative lifetime totals that the BMS persists and never resets, so they
+    # use state_class TOTAL with a time unit (per HA docs, TOTAL_INCREASING is
+    # for meters that periodically restart from 0 - not the case here).
     # NOTE: we deliberately do NOT set device_class DURATION here. This
     # integration renders DURATION values as a human "Xd Yh Zm" string and
     # clears the state_class (see sensor/entities.py), which would break the
@@ -145,7 +146,7 @@ VW_EUP_METRICS = {
         "name": "VW eUP! Battery Time Charged AC",
         "description": "Total lifetime time the battery has been AC charged",
         "icon": "mdi:current-ac",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "unit": UnitOfTime.HOURS,
         "suggested_display_precision": 2,
         "category": "vw_eup",
@@ -154,7 +155,7 @@ VW_EUP_METRICS = {
         "name": "VW eUP! Battery Time Charged DC",
         "description": "Total lifetime time the battery has been DC charged",
         "icon": "mdi:current-dc",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "unit": UnitOfTime.HOURS,
         "suggested_display_precision": 2,
         "category": "vw_eup",
@@ -163,7 +164,7 @@ VW_EUP_METRICS = {
         "name": "VW eUP! Battery Time Parked",
         "description": "Total lifetime time the vehicle has been parked",
         "icon": "mdi:clock-outline",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "unit": UnitOfTime.DAYS,
         "suggested_display_precision": 2,
         "category": "vw_eup",
@@ -172,7 +173,7 @@ VW_EUP_METRICS = {
         "name": "VW eUP! Battery Time Parked Cold",
         "description": "Total lifetime time parked with battery below 0 °C",
         "icon": "mdi:thermometer-low",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "unit": UnitOfTime.DAYS,
         "suggested_display_precision": 2,
         "category": "vw_eup",
@@ -181,7 +182,7 @@ VW_EUP_METRICS = {
         "name": "VW eUP! Battery Time Parked Empty",
         "description": "Total lifetime time parked below 10% SOC",
         "icon": "mdi:battery-low",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "unit": UnitOfTime.DAYS,
         "suggested_display_precision": 2,
         "category": "vw_eup",
@@ -190,7 +191,7 @@ VW_EUP_METRICS = {
         "name": "VW eUP! Battery Time Parked Full",
         "description": "Total lifetime time parked above 90% SOC",
         "icon": "mdi:battery-high",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "unit": UnitOfTime.DAYS,
         "suggested_display_precision": 2,
         "category": "vw_eup",
@@ -199,7 +200,7 @@ VW_EUP_METRICS = {
         "name": "VW eUP! Battery Time Parked Hot",
         "description": "Total lifetime time parked with battery above 30 °C",
         "icon": "mdi:thermometer-high",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "unit": UnitOfTime.DAYS,
         "suggested_display_precision": 2,
         "category": "vw_eup",
@@ -208,7 +209,7 @@ VW_EUP_METRICS = {
         "name": "VW eUP! Battery Total Age",
         "description": "Total lifetime age of the high-voltage battery",
         "icon": "mdi:battery-clock",
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "unit": UnitOfTime.DAYS,
         "suggested_display_precision": 2,
         "category": "vw_eup",

--- a/custom_components/ovms/metrics/vehicles/vw_eup.py
+++ b/custom_components/ovms/metrics/vehicles/vw_eup.py
@@ -139,9 +139,10 @@ VW_EUP_METRICS = {
     # clears the state_class (see sensor/entities.py), which would break the
     # long-term statistics that make these accumulators useful. A plain numeric
     # sensor with unit d/h keeps them graphable.
-    # The 6x8 SOC/temperature park-time matrix (xvu.b.time.parked.state) is
-    # intentionally omitted: it has no meaningful single state and is a niche
-    # web-UI diagnostic.
+    # The 6x8 SOC/temperature park-time matrix (xvu.b.time.parked.state) is a
+    # 48-value vector with no meaningful single sensor state, so it is
+    # suppressed via SYSTEM_TOPIC_BLACKLIST in const.py rather than surfaced as
+    # a broken/truncated entity; its useful aggregates are the scalars above.
     "xvu.b.time.charged.ac": {
         "name": "VW eUP! Battery Time Charged AC",
         "description": "Total lifetime time the battery has been AC charged",

--- a/custom_components/ovms/metrics/vehicles/vw_eup.py
+++ b/custom_components/ovms/metrics/vehicles/vw_eup.py
@@ -130,6 +130,89 @@ VW_EUP_METRICS = {
         "unit": PERCENTAGE,
         "category": "vw_eup",
     },
+    # Battery health / aging counters, new in OVMS firmware 3.3.006. These are
+    # cumulative lifetime totals (the BMS only ever increases them) whose value
+    # is meant to be trended, so they are TOTAL_INCREASING with a time unit.
+    # NOTE: we deliberately do NOT set device_class DURATION here. This
+    # integration renders DURATION values as a human "Xd Yh Zm" string and
+    # clears the state_class (see sensor/entities.py), which would break the
+    # long-term statistics that make these accumulators useful. A plain numeric
+    # sensor with unit d/h keeps them graphable.
+    # The 6x8 SOC/temperature park-time matrix (xvu.b.time.parked.state) is
+    # intentionally omitted: it has no meaningful single state and is a niche
+    # web-UI diagnostic.
+    "xvu.b.time.charged.ac": {
+        "name": "VW eUP! Battery Time Charged AC",
+        "description": "Total lifetime time the battery has been AC charged",
+        "icon": "mdi:current-ac",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfTime.HOURS,
+        "suggested_display_precision": 2,
+        "category": "vw_eup",
+    },
+    "xvu.b.time.charged.dc": {
+        "name": "VW eUP! Battery Time Charged DC",
+        "description": "Total lifetime time the battery has been DC charged",
+        "icon": "mdi:current-dc",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfTime.HOURS,
+        "suggested_display_precision": 2,
+        "category": "vw_eup",
+    },
+    "xvu.b.time.parked": {
+        "name": "VW eUP! Battery Time Parked",
+        "description": "Total lifetime time the vehicle has been parked",
+        "icon": "mdi:clock-outline",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfTime.DAYS,
+        "suggested_display_precision": 2,
+        "category": "vw_eup",
+    },
+    "xvu.b.time.parked.cold": {
+        "name": "VW eUP! Battery Time Parked Cold",
+        "description": "Total lifetime time parked with battery below 0 °C",
+        "icon": "mdi:thermometer-low",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfTime.DAYS,
+        "suggested_display_precision": 2,
+        "category": "vw_eup",
+    },
+    "xvu.b.time.parked.empty": {
+        "name": "VW eUP! Battery Time Parked Empty",
+        "description": "Total lifetime time parked below 10% SOC",
+        "icon": "mdi:battery-low",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfTime.DAYS,
+        "suggested_display_precision": 2,
+        "category": "vw_eup",
+    },
+    "xvu.b.time.parked.full": {
+        "name": "VW eUP! Battery Time Parked Full",
+        "description": "Total lifetime time parked above 90% SOC",
+        "icon": "mdi:battery-high",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfTime.DAYS,
+        "suggested_display_precision": 2,
+        "category": "vw_eup",
+    },
+    "xvu.b.time.parked.hot": {
+        "name": "VW eUP! Battery Time Parked Hot",
+        "description": "Total lifetime time parked with battery above 30 °C",
+        "icon": "mdi:thermometer-high",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfTime.DAYS,
+        "suggested_display_precision": 2,
+        "category": "vw_eup",
+    },
+    "xvu.b.time.total": {
+        "name": "VW eUP! Battery Total Age",
+        "description": "Total lifetime age of the high-voltage battery",
+        "icon": "mdi:battery-clock",
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "unit": UnitOfTime.DAYS,
+        "suggested_display_precision": 2,
+        "category": "vw_eup",
+    },
     "xvu.c.ac.i1": {
         "name": "VW eUP! AC Charging Current L1",
         "description": "AC charging current phase 1",

--- a/scripts/tests/test_vw_eup_battery_age.py
+++ b/scripts/tests/test_vw_eup_battery_age.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Regression test for the VW e-Up battery-aging metrics (OVMS 3.3.006).
+
+Firmware 3.3.006 adds cumulative battery health/aging counters:
+  xvu.b.time.total / parked / parked.cold / parked.empty / parked.full /
+  parked.hot  -> Days, and charged.ac / charged.dc -> Hours.
+They are lifetime accumulators, so each is a DURATION sensor with state_class
+TOTAL_INCREASING. This test asserts every definition is typed correctly and
+that a real OVMSSensor produces the numeric value with the right unit.
+
+Run standalone:  python3 scripts/tests/test_vw_eup_battery_age.py
+Exits non-zero on failure.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from homeassistant.components.sensor import SensorStateClass
+from homeassistant.const import UnitOfTime
+
+import custom_components.ovms.sensor.entities as entities_mod
+
+from custom_components.ovms.sensor.entities import OVMSSensor
+from custom_components.ovms.attribute_manager import AttributeManager
+from custom_components.ovms.metrics import get_metric_by_path
+
+DAYS_METRICS = [
+    "xvu.b.time.total",
+    "xvu.b.time.parked",
+    "xvu.b.time.parked.cold",
+    "xvu.b.time.parked.empty",
+    "xvu.b.time.parked.full",
+    "xvu.b.time.parked.hot",
+]
+HOURS_METRICS = ["xvu.b.time.charged.ac", "xvu.b.time.charged.dc"]
+
+entities_mod.async_dispatcher_connect = lambda *a, **k: (lambda: None)
+
+
+class _TestSensor(OVMSSensor):
+    async def async_get_last_state(self):
+        return None
+
+    def async_write_ha_state(self):
+        pass
+
+
+def _check(name, cond, results):
+    results.append(cond)
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+
+def main():
+    print("VW e-Up battery-aging metrics regression test")
+    print("-" * 55)
+    results = []
+
+    for path, unit in [(p, UnitOfTime.DAYS) for p in DAYS_METRICS] + [
+        (p, UnitOfTime.HOURS) for p in HOURS_METRICS
+    ]:
+        m = get_metric_by_path(path)
+        ok = (
+            m is not None
+            and m["state_class"] == SensorStateClass.TOTAL_INCREASING
+            and m["unit"] == unit
+            and m.get("category") == "vw_eup"
+            and m.get("suggested_display_precision") == 2
+            # Intentionally NOT DURATION: the integration would format the value
+            # as a "Xd Yh" string and drop state_class, breaking statistics.
+            and m.get("device_class") is None
+        )
+        _check(
+            f"{path}: numeric TOTAL_INCREASING / {unit} / no device_class", ok, results
+        )
+
+    # Real OVMSSensor smoke test for one metric.
+    path = "xvu.b.time.total"
+    topic = "ovms/u/eup/metric/xvu/b/time/total"
+    m = get_metric_by_path(path)
+    attrs = AttributeManager({}).prepare_attributes(
+        topic, m["category"], topic.split("/")[3:], m
+    )
+    sensor = _TestSensor(
+        "ovms_test_eup_total",
+        "ovms_eup_total",
+        topic,
+        "365.50",
+        {},
+        attrs,
+        m["name"],
+        None,
+    )
+    _check(
+        "OVMSSensor state = 365.5 (numeric float, NOT a '365d 12h' string)",
+        sensor.native_value == 365.5,
+        results,
+    )
+    _check(
+        "OVMSSensor unit=d, no device_class, state_class=total_increasing",
+        sensor.native_unit_of_measurement == UnitOfTime.DAYS
+        and sensor.device_class is None
+        and sensor.state_class == SensorStateClass.TOTAL_INCREASING,
+        results,
+    )
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_vw_eup_battery_age.py
+++ b/scripts/tests/test_vw_eup_battery_age.py
@@ -25,6 +25,8 @@ import custom_components.ovms.sensor.entities as entities_mod
 from custom_components.ovms.sensor.entities import OVMSSensor
 from custom_components.ovms.attribute_manager import AttributeManager
 from custom_components.ovms.metrics import get_metric_by_path
+from custom_components.ovms.mqtt.topic_parser import TopicParser
+from custom_components.ovms.mqtt.entity_registry import EntityRegistry
 
 DAYS_METRICS = [
     "xvu.b.time.total",
@@ -100,6 +102,30 @@ def main():
         sensor.native_unit_of_measurement == UnitOfTime.DAYS
         and sensor.device_class is None
         and sensor.state_class == SensorStateClass.TOTAL,
+        results,
+    )
+
+    # The 48-value park-time matrix must be suppressed (blacklisted), while the
+    # scalar metrics must still create sensors.
+    parser = TopicParser(
+        {
+            "vehicle_id": "eup",
+            "topic_prefix": "ovms",
+            "mqtt_username": "ovmsuser",
+            "topic_structure": "{prefix}/{mqtt_username}/{vehicle_id}",
+        },
+        EntityRegistry(),
+    )
+    base = "ovms/ovmsuser/eup/metric/xvu/b/time"
+    _check(
+        "park-time matrix topic is suppressed (no entity)",
+        parser.parse_topic(f"{base}/parked/state", "1,2,3") is None,
+        results,
+    )
+    _check(
+        "scalar parked topic still creates a sensor (not over-blacklisted)",
+        (parser.parse_topic(f"{base}/parked", "300.25") or {}).get("entity_type")
+        == "sensor",
         results,
     )
 

--- a/scripts/tests/test_vw_eup_battery_age.py
+++ b/scripts/tests/test_vw_eup_battery_age.py
@@ -63,7 +63,7 @@ def main():
         m = get_metric_by_path(path)
         ok = (
             m is not None
-            and m["state_class"] == SensorStateClass.TOTAL_INCREASING
+            and m["state_class"] == SensorStateClass.TOTAL
             and m["unit"] == unit
             and m.get("category") == "vw_eup"
             and m.get("suggested_display_precision") == 2
@@ -71,9 +71,7 @@ def main():
             # as a "Xd Yh" string and drop state_class, breaking statistics.
             and m.get("device_class") is None
         )
-        _check(
-            f"{path}: numeric TOTAL_INCREASING / {unit} / no device_class", ok, results
-        )
+        _check(f"{path}: numeric TOTAL / {unit} / no device_class", ok, results)
 
     # Real OVMSSensor smoke test for one metric.
     path = "xvu.b.time.total"
@@ -98,10 +96,10 @@ def main():
         results,
     )
     _check(
-        "OVMSSensor unit=d, no device_class, state_class=total_increasing",
+        "OVMSSensor unit=d, no device_class, state_class=total",
         sensor.native_unit_of_measurement == UnitOfTime.DAYS
         and sensor.device_class is None
-        and sensor.state_class == SensorStateClass.TOTAL_INCREASING,
+        and sensor.state_class == SensorStateClass.TOTAL,
         results,
     )
 


### PR DESCRIPTION
## What

OVMS firmware **3.3.006** adds lifetime battery health/aging counters for the VW e-Up. This adds the 8 scalar `xvu.b.time.*` metrics:

| Metric | Meaning | Unit |
|---|---|---|
| `xvu.b.time.total` | Total HV battery age | Days |
| `xvu.b.time.parked` | Total time parked | Days |
| `xvu.b.time.parked.cold` | Time parked below 0 °C | Days |
| `xvu.b.time.parked.empty` | Time parked below 10% SOC | Days |
| `xvu.b.time.parked.full` | Time parked above 90% SOC | Days |
| `xvu.b.time.parked.hot` | Time parked above 30 °C | Days |
| `xvu.b.time.charged.ac` | Total time charged AC | Hours |
| `xvu.b.time.charged.dc` | Total time charged DC | Hours |

## Design note (why not `device_class: DURATION`)

These are cumulative lifetime accumulators (the BMS only increases them), so they use `state_class: TOTAL_INCREASING` with a time unit — the point is to *trend* them. They are deliberately **not** `device_class: DURATION`: this integration renders DURATION values as a human `"365d 12h"` string and clears the `state_class` (see `sensor/entities.py`), which would break the long-term statistics. Keeping them numeric (`d`/`h`) keeps them graphable. I confirmed the allowed unit/state-class combos against the HA sensor API before choosing.

The 6×8 SOC/temperature park-time matrix (`xvu.b.time.parked.state`, a 48-value `InitVector<float>`) is intentionally **omitted** — it has no meaningful single state and is a niche web-UI diagnostic.

## Tests

- `scripts/tests/test_vw_eup_battery_age.py` — asserts all 8 definitions are numeric `TOTAL_INCREASING` with the correct units and no `device_class`, and drives a real `OVMSSensor` to confirm the value stays a numeric `365.5` (not a `"365d 12h"` string).
- Existing gates pass (black, `scripts/tests/test_code_quality.py`, pylint aggregate).
- Live Home Assistant validation (entities created, debug logs, UI) is being added as a follow-up comment.

Ref: OVMS firmware 3.3.006 changelog (VW e-Up extended battery health / aging info).