### PR TITLE
Don't expose vector config keys as user-facing attributes

### DIFF
--- a/custom_components/ovms/sensor/entities.py
+++ b/custom_components/ovms/sensor/entities.py
@@ -389,6 +389,15 @@ class OVMSSensor(SensorEntity, RestoreEntity):
             **attributes,
             "topic": topic,
         }
+        # Consume the vector config keys (if the metric declares them) into
+        # instance state so they drive _try_parse_vector without surfacing as
+        # confusing user-facing attributes. See issue #224.
+        self._vector_labels = self._attr_extra_state_attributes.pop(
+            "vector_attributes", None
+        )
+        self._vector_state_label = self._attr_extra_state_attributes.pop(
+            "vector_state", None
+        )
         self.hass: Optional[HomeAssistant] = hass
 
         # Determine sensor type
@@ -705,8 +714,8 @@ class OVMSSensor(SensorEntity, RestoreEntity):
         every metric that doesn't declare a vector, so existing sensors are
         unaffected. See OVMS metric xsq.bms.contactor.cycles and issue #224.
         """
-        labels = self._attr_extra_state_attributes.get("vector_attributes")
-        state_label = self._attr_extra_state_attributes.get("vector_state")
+        labels = self._vector_labels
+        state_label = self._vector_state_label
         if not labels or not state_label:
             return False
 

--- a/scripts/tests/test_contactor_cycles.py
+++ b/scripts/tests/test_contactor_cycles.py
@@ -120,6 +120,11 @@ async def main():
         and a.get("cycles_last_hour") == 3,
         results,
     )
+    _check(
+        "vector config keys are NOT leaked as user-facing attributes",
+        "vector_attributes" not in a and "vector_state" not in a,
+        results,
+    )
 
     # ---- a live update reflecting cycles being consumed ----
     _send(f"{SIGNAL_UPDATE_ENTITY}_{sensor.unique_id}", "200000,198400,1600,100,5")


### PR DESCRIPTION
## Problem

The vector-sensor mechanism added in #224/#227 lets a metric declare `vector_attributes` and `vector_state` (config that drives how a CSV vector like `xsq.bms.contactor.cycles` is split into a state + named attributes). But `AttributeManager.prepare_attributes` copies every metric key into the entity's `extra_state_attributes`, so those two **config** keys leaked into the user-facing attributes — e.g. the contactor sensor showed `vector_attributes: [max, now, ...]` and `vector_state: now` next to the real values.

## Fix

Consume `vector_attributes`/`vector_state` into instance state (`self._vector_labels` / `self._vector_state_label`) in `OVMSSensor.__init__` and `pop()` them off the attributes dict. `_try_parse_vector` now reads the instance fields, so the parsing still works but the config keys no longer surface as attributes. No other metric is affected (the fields are absent for them).

## Tests

`scripts/tests/test_contactor_cycles.py` gains a check that `vector_attributes`/`vector_state` are not in the entity's attributes; all checks pass. Live-verified in a running HA (Smart ForTwo contactor sensor) — see comment.

Follow-up to #227.