### PR TITLE
Route commands to the correct vehicle's broker connection

### DIFF
--- a/custom_components/ovms/mqtt/command_handler.py
+++ b/custom_components/ovms/mqtt/command_handler.py
@@ -10,6 +10,7 @@ from typing import Dict, Any, Optional
 from homeassistant.core import HomeAssistant
 
 from ..const import (
+    DOMAIN,
     LOGGER_NAME,
     CONF_QOS,
     CONF_VEHICLE_ID,
@@ -125,6 +126,27 @@ class CommandHandler:
                 # Wait a bit before retrying to avoid tight loop
                 await asyncio.sleep(5)
 
+    def _get_connection_manager(self, vehicle_id: str = None):
+        """Return the MQTT connection manager for the targeted vehicle.
+
+        Each config entry owns one OVMSMQTTClient, stored in hass.data keyed by
+        entry_id. Match the entry whose vehicle_id equals the requested one
+        (defaulting to this handler's own vehicle) so a command publishes over
+        the correct broker connection. The previous logic compared the handler's
+        own config against itself, so in a multi-vehicle setup it returned the
+        first connected client's connection manager regardless of vehicle.
+        """
+        target_vehicle_id = vehicle_id or self.config.get(CONF_VEHICLE_ID)
+        for data in self.hass.data.get(DOMAIN, {}).values():
+            if not isinstance(data, dict):
+                continue
+            client = data.get("mqtt_client")
+            if client is None or not hasattr(client, "connection_manager"):
+                continue
+            if client.config.get(CONF_VEHICLE_ID) == target_vehicle_id:
+                return client.connection_manager
+        return None
+
     async def async_send_command(
         self,
         command: str,
@@ -134,16 +156,8 @@ class CommandHandler:
         vehicle_id: str = None,
     ) -> Dict[str, Any]:
         """Send a command to the OVMS module and wait for a response."""
-        # Get the MQTT client
-        mqtt_client = None
-        for entry_id, data in self.hass.data["ovms"].items():
-            if "mqtt_client" in data and hasattr(
-                data["mqtt_client"], "connection_manager"
-            ):
-                current_vehicle_id = vehicle_id or self.config.get(CONF_VEHICLE_ID)
-                if current_vehicle_id == self.config.get(CONF_VEHICLE_ID):
-                    mqtt_client = data["mqtt_client"].connection_manager
-                    break
+        # Resolve the connection manager for the targeted vehicle.
+        mqtt_client = self._get_connection_manager(vehicle_id)
 
         if not mqtt_client or not mqtt_client.connected:
             _LOGGER.error("Cannot send command, not connected to MQTT broker")

--- a/scripts/tests/test_command_routing.py
+++ b/scripts/tests/test_command_routing.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Regression test for multi-vehicle OVMS command routing.
+
+Each OVMS config entry owns one ``OVMSMQTTClient`` (one vehicle) and its own
+``CommandHandler``. When a command is sent, the handler must publish over the
+connection manager of *its own* entry.
+
+The previous selection loop compared the handler's own ``vehicle_id`` against
+itself for every entry::
+
+    current_vehicle_id = vehicle_id or self.config.get(CONF_VEHICLE_ID)
+    if current_vehicle_id == self.config.get(CONF_VEHICLE_ID):  # always true
+        mqtt_client = data["mqtt_client"].connection_manager
+
+so in a multi-vehicle setup it returned the **first** connected client's
+connection manager regardless of which vehicle the handler belonged to (a
+wrong-broker publish when vehicles use different brokers), and an explicit,
+non-matching ``vehicle_id`` could never resolve.
+
+This drives the REAL ``CommandHandler._get_connection_manager`` against a fake
+``hass.data`` holding two vehicles and asserts each handler resolves its own
+vehicle's connection manager.
+
+Run standalone:  python3 scripts/tests/test_command_routing.py
+Exits non-zero on failure.
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from custom_components.ovms.mqtt.command_handler import CommandHandler
+from custom_components.ovms.const import CONF_VEHICLE_ID, DOMAIN
+
+
+class _Sentinel:
+    """Stands in for a connection manager; identity is what we assert on."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeClient:
+    """Minimal OVMSMQTTClient stand-in with a config and connection manager."""
+
+    def __init__(self, vehicle_id):
+        self.config = {CONF_VEHICLE_ID: vehicle_id}
+        self.connection_manager = _Sentinel(vehicle_id)
+
+
+class _FakeHass:
+    def __init__(self, data):
+        self.data = data
+
+
+def _check(name, cond, results):
+    results.append(cond)
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+
+async def _make_handler(hass, vehicle_id):
+    return CommandHandler(hass, {CONF_VEHICLE_ID: vehicle_id})
+
+
+async def _stop(handler):
+    handler._cleanup_task.cancel()
+    await asyncio.gather(handler._cleanup_task, return_exceptions=True)
+
+
+async def main():
+    print("OVMS multi-vehicle command routing regression test")
+    print("-" * 55)
+    results = []
+
+    client_a = _FakeClient("A")
+    client_b = _FakeClient("B")
+    # 'A' is intentionally FIRST so the old "pick the first client" bug would
+    # have selected it for every handler.
+    hass = _FakeHass(
+        {
+            DOMAIN: {
+                "entry_a": {"mqtt_client": client_a},
+                "entry_b": {"mqtt_client": client_b},
+            }
+        }
+    )
+
+    handler_b = await _make_handler(hass, "B")
+    handler_a = await _make_handler(hass, "A")
+    try:
+        _check(
+            "handler for B resolves B's connection manager (not first entry A)",
+            handler_b._get_connection_manager() is client_b.connection_manager,
+            results,
+        )
+        _check(
+            "handler for A resolves A's connection manager",
+            handler_a._get_connection_manager() is client_a.connection_manager,
+            results,
+        )
+        _check(
+            "explicit vehicle_id 'A' resolves A's connection manager",
+            handler_b._get_connection_manager("A") is client_a.connection_manager,
+            results,
+        )
+        _check(
+            "unknown vehicle resolves to None",
+            handler_b._get_connection_manager("ZZZ") is None,
+            results,
+        )
+    finally:
+        await _stop(handler_a)
+        await _stop(handler_b)
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Problem

`CommandHandler.async_send_command` picked the MQTT connection by looping over every config entry in `hass.data[DOMAIN]` and comparing the handler's **own** vehicle against **itself**:

```python
current_vehicle_id = vehicle_id or self.config.get(CONF_VEHICLE_ID)
if current_vehicle_id == self.config.get(CONF_VEHICLE_ID):  # always True
    mqtt_client = data["mqtt_client"].connection_manager
    break
```

That condition is always true, so the loop returned the **first** connected client's connection manager regardless of which vehicle the handler belonged to.

- **Single vehicle:** harmless (there's only one entry).
- **Multiple vehicles:** a command could be published over the *wrong* broker connection (matters when vehicles use different brokers). Each `CommandHandler` still formats the topic with its own `structure_prefix`, so on a shared broker the command usually still arrives, but the connection selection is incorrect.
- An explicit `vehicle_id` that differs from the handler's own config could **never** resolve a client → spurious "Not connected".

## Fix

Extract the lookup into `_get_connection_manager(vehicle_id)` and match the entry whose **client's** `vehicle_id` equals the requested one (defaulting to this handler's own vehicle). Single-vehicle behavior is byte-for-byte identical; multi-vehicle commands now route to the right connection. Also adds defensive `isinstance(data, dict)` / `.get("mqtt_client")` guards and replaces the `"ovms"` string literal with the `DOMAIN` constant.

## Tests

New `scripts/tests/test_command_routing.py` drives the real `_get_connection_manager` against a fake two-vehicle `hass.data` (with the *other* vehicle listed first, so the old "pick the first" bug would fail) and asserts each handler resolves its own vehicle's connection manager, explicit `vehicle_id` targeting works, and an unknown vehicle resolves to `None`. All 4 checks pass; `black` clean; `pylint` 9.63/10 on the changed module.

### Note
The full broker round-trip in a real multi-vehicle / multi-broker install was not exercised live (it needs a responding OVMS device per broker); the regression test covers the selection logic deterministically.