### PR TITLE
Give undefined vehicle-specific metrics a real entity name

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,6 +172,15 @@ System blacklist patterns in `const.py::SYSTEM_TOPIC_BLACKLIST` prevent high-fre
 - GPS accuracy: calculated from signal quality metrics
 - Cell statistics: min/max/avg/median for array data stored as attributes
 
+## Entity Naming Conventions
+
+Entity names must identify the vehicle **at most once**, and stay short (the UI is mostly used on mobile phones).
+
+- The Home Assistant **device** is named after the `vehicle_id` (e.g. the user's plate), so with `has_entity_name` it already prefixes every entity in dashboards/lists. Do **not** repeat the vehicle in the entity name to "make sure" it is identified.
+- For vehicle-specific metrics, the make/model belongs in the name **only as a trailing `(Make Model)` suffix**, added automatically by `naming_service.create_friendly_name`. Write the metric `name` with the make/model as a **leading** label (e.g. `"VW eUP! Battery Total Age"`); the naming service strips that prefix and re-appends it once as the suffix → `"Battery Total Age (VW eUP!)"`. Never hard-code the `(Make Model)` suffix in a metric `name`, and never end up with both a prefix and a suffix.
+- The make/model labels live in `const.VEHICLE_TOPIC_PREFIXES` (keyed by topic prefix); a vehicle module's `VEHICLE_NAME` must match its label there.
+- A vehicle-specific topic with **no** metric definition must still get a descriptor derived from the topic (e.g. `"E Dcdc State (VW eUP!)"`), never just the bare make/model label.
+
 ## Development Workflows
 
 ### Adding Vehicle Support

--- a/custom_components/ovms/naming_service.py
+++ b/custom_components/ovms/naming_service.py
@@ -45,6 +45,23 @@ class EntityNamingService:
                         return f"{base_name} {module_number} ({vehicle_label})"
                     return f"{base_name} ({vehicle_label})"
 
+            # A prefix-pattern match (a vehicle-specific topic with no specific
+            # metric definition) leaves base_name as just the bare vehicle label,
+            # e.g. "VW eUP!". Derive a descriptor from the topic segments after
+            # the vehicle prefix so the entity reads "B Soc (VW eUP!)" instead of
+            # only "VW eUP!" repeated across every undefined metric.
+            if base_name in VEHICLE_TOPIC_PREFIXES.values():
+                tail = []
+                seen_prefix = False
+                for part in parts or []:
+                    if seen_prefix:
+                        tail.append(part)
+                    elif part in VEHICLE_TOPIC_PREFIXES:
+                        seen_prefix = True
+                if tail:
+                    descriptor = " ".join(tail).replace("_", " ").title()
+                    return f"{descriptor} ({base_name})"
+
             # If topic ends with a number (like /03), append it to the name
             if topic and topic.split("/")[-1].isdigit():
                 module_number = topic.split("/")[-1]

--- a/scripts/tests/test_vehicle_entity_naming.py
+++ b/scripts/tests/test_vehicle_entity_naming.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Regression test for vehicle-specific entity naming.
+
+OVMS publishes many vehicle-specific topics (xvu/*, xsq/*, …) that have no
+explicit metric definition. Those fall back to the prefix pattern in
+``metrics/patterns.py`` whose ``name`` is just the bare vehicle label
+("VW eUP!", "Smart ForTwo", …). ``create_friendly_name`` used to return that
+label verbatim, so every undefined vehicle metric showed up as only
+"VW eUP!" with no descriptor (and collided in the UI).
+
+The fix derives a descriptor from the topic segments after the vehicle prefix,
+so an undefined ``xvu/b/soc`` reads "B Soc (VW eUP!)". This test drives the real
+``EntityNamingService.create_friendly_name`` and checks the fix plus the
+existing naming paths (defined vehicle metric, plain metric) still work.
+
+Run standalone:  python3 scripts/tests/test_vehicle_entity_naming.py
+Exits non-zero on failure.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from custom_components.ovms.naming_service import EntityNamingService
+
+
+def _parts(topic):
+    """Mimic the topic parser: segments after the vehicle id."""
+    return topic.split("/eup/", 1)[-1].split("/")
+
+
+def _check(name, got, want, results):
+    ok = got == want
+    results.append(ok)
+    print(
+        f"  {'PASS' if ok else 'FAIL'}  {name}: {got!r}"
+        + ("" if ok else f" != {want!r}")
+    )
+
+
+def main():
+    print("OVMS vehicle-specific entity naming regression test")
+    print("-" * 55)
+    results = []
+    svc = EntityNamingService({"vehicle_id": "eup"})
+
+    # 1) Undefined xvu metric -> prefix pattern name is the bare label.
+    topic = "ovms/u/eup/metric/xvu/b/soc"
+    label_pattern = {"name": "VW eUP!", "category": "vw_eup"}
+    _check(
+        "undefined xvu metric gets a descriptor",
+        svc.create_friendly_name(_parts(topic), label_pattern, topic, "xvu_b_soc"),
+        "B Soc (VW eUP!)",
+        results,
+    )
+
+    # 2) Another vehicle's undefined metric.
+    topic2 = "ovms/u/eup/metric/xsq/bms/amps"
+    _check(
+        "undefined xsq metric gets a descriptor",
+        svc.create_friendly_name(
+            _parts(topic2), {"name": "Smart ForTwo"}, topic2, "xsq_bms_amps"
+        ),
+        "Bms Amps (Smart ForTwo)",
+        results,
+    )
+
+    # 3) A DEFINED vehicle metric (name carries the label prefix) is unchanged.
+    topic3 = "ovms/u/eup/metric/xvu/b/soh/total"
+    _check(
+        "defined vehicle metric keeps its name + single suffix",
+        svc.create_friendly_name(
+            _parts(topic3),
+            {"name": "VW eUP! Battery Total Age"},
+            topic3,
+            "x",
+        ),
+        "Battery Total Age (VW eUP!)",
+        results,
+    )
+
+    # 4) A plain (non-vehicle) metric is untouched (no suffix).
+    topic4 = "ovms/u/eup/metric/v/b/soc"
+    _check(
+        "plain metric name is returned unchanged",
+        svc.create_friendly_name(_parts(topic4), {"name": "Battery SOC"}, topic4, "x"),
+        "Battery SOC",
+        results,
+    )
+
+    # 5) Bare label with no usable topic parts falls back to the label.
+    _check(
+        "bare label with no parts falls back to the label",
+        svc.create_friendly_name([], {"name": "VW eUP!"}, "", ""),
+        "VW eUP!",
+        results,
+    )
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

OVMS publishes many vehicle-specific topics (`xvu/*`, `xsq/*`, …) that have no explicit metric definition. Those fall back to the prefix pattern in `metrics/patterns.py`, whose `name` is just the bare vehicle label (`"VW eUP!"`, `"Smart ForTwo"`, …). `create_friendly_name` returned that label verbatim, so **every** such metric showed up in the UI as only **"VW eUP!"** with no descriptor — a column of identical, meaningless names (see the device page where 8 entities all read "VW eUP!").

## Fix

When the matched name is a bare vehicle label, derive a descriptor from the topic segments **after** the vehicle prefix, so `xvu/e/dcdc/state` reads **"E Dcdc State (VW eUP!)"** instead of just "VW eUP!". 

- Defined vehicle metrics (whose name starts with the label, e.g. `"VW eUP! Battery Total Age"`) are unchanged — they still strip the leading label and re-append it once → `"Battery Total Age (VW eUP!)"`.
- Plain (non-vehicle) metrics are untouched.
- A topic with nothing after the prefix still falls back to the bare label (nothing to describe).

## Tests

New `scripts/tests/test_vehicle_entity_naming.py` drives the real `create_friendly_name`: undefined `xvu` and `xsq` metrics get descriptors, a defined metric keeps its single suffix, a plain metric is unchanged, and the no-parts fallback returns the label. All pass.

**Live-verified** on a running HA: publishing undefined `xvu/e/dcdc/state`, `xvu/e/hvcontactor/state`, etc. now produces `"E Dcdc State (VW eUP!)"`, `"E Hvcontactor State (VW eUP!)"` — no more bare "VW eUP!" rows on the device page.