### PR TITLE
Fix v.b.consumption metric typing (momentary efficiency, not energy total)

### DIFF
--- a/custom_components/ovms/metrics/common/battery.py
+++ b/custom_components/ovms/metrics/common/battery.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfEnergyDistance,
     UnitOfLength,
     UnitOfPower,
     UnitOfSpeed,
@@ -165,11 +166,17 @@ BATTERY_METRICS = {
     },
     "v.b.consumption": {
         "name": "Battery Consumption",
+        # OVMS v.b.consumption is the momentary energy-per-distance efficiency
+        # (firmware unit: Wh/km), not a cumulative energy total. Typing it as
+        # ENERGY + TOTAL told HA to treat it as an accumulating meter, which
+        # distorted long-term statistics. HA's ENERGY_DISTANCE device class is
+        # purpose-built for this: it accepts the Wh/km unit, requires
+        # state_class MEASUREMENT, and gives users unit-system conversion.
         "description": "Main battery momentary consumption",
         "icon": "mdi:battery-minus",
-        "device_class": SensorDeviceClass.ENERGY,
-        "state_class": SensorStateClass.TOTAL,
-        "unit": UnitOfEnergy.WATT_HOUR,
+        "device_class": SensorDeviceClass.ENERGY_DISTANCE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "unit": UnitOfEnergyDistance.WATT_HOUR_PER_KM,
         "category": "battery",
     },
     "v.b.coulomb.recd": {

--- a/scripts/tests/test_battery_consumption_metric.py
+++ b/scripts/tests/test_battery_consumption_metric.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Regression test for the v.b.consumption metric typing.
+
+OVMS `v.b.consumption` is the *momentary* battery energy-per-distance efficiency
+(firmware unit: Wh/km), not a cumulative energy total. It was typed as
+`device_class=ENERGY` + `state_class=TOTAL` + `unit=Wh`, which tells Home
+Assistant to treat it as an accumulating energy meter and distorts long-term
+statistics.
+
+This asserts it now uses HA's purpose-built `ENERGY_DISTANCE` device class with
+`state_class=MEASUREMENT` and the `Wh/km` unit constant.
+
+Run standalone:  python3 scripts/tests/test_battery_consumption_metric.py
+Exits non-zero on failure.
+"""
+
+# pylint: disable=duplicate-code
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergyDistance
+
+from custom_components.ovms.metrics import get_metric_by_path
+
+
+def _check(name, cond, results):
+    results.append(cond)
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+
+def main():
+    print("OVMS v.b.consumption metric typing regression test")
+    print("-" * 55)
+    results = []
+
+    metric = get_metric_by_path("v.b.consumption")
+    _check("metric is defined", metric is not None, results)
+    if metric:
+        _check(
+            "device_class is ENERGY_DISTANCE (HA-native energy-per-distance)",
+            metric.get("device_class") == SensorDeviceClass.ENERGY_DISTANCE,
+            results,
+        )
+        _check(
+            "state_class is MEASUREMENT (required by ENERGY_DISTANCE)",
+            metric.get("state_class") == SensorStateClass.MEASUREMENT,
+            results,
+        )
+        _check(
+            "unit is the HA Wh/km constant (UnitOfEnergyDistance.WATT_HOUR_PER_KM)",
+            metric.get("unit") == UnitOfEnergyDistance.WATT_HOUR_PER_KM,
+            results,
+        )
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

`v.b.consumption` was typed `device_class=ENERGY`, `state_class=TOTAL`, `unit=Wh`, but per OVMS firmware (`metrics_standard.h`, `ms_v_bat_consumption`) it is **"Main battery momentary consumption [Wh/km]"** — an *instantaneous* energy-per-distance efficiency, not a cumulative energy total. Typing a momentary value as `ENERGY` + `TOTAL` tells HA's long-term statistics to treat it as an ever-accumulating meter, which corrupts the statistics for that sensor.

## Fix

Use Home Assistant's purpose-built energy-per-distance device class rather than a generic `device_class=None` + hardcoded unit string:

- `device_class`: `ENERGY` → `SensorDeviceClass.ENERGY_DISTANCE`
- `state_class`: `TOTAL` → `MEASUREMENT` (the only state_class `ENERGY_DISTANCE` permits)
- `unit`: `UnitOfEnergy.WATT_HOUR` → `UnitOfEnergyDistance.WATT_HOUR_PER_KM` (`"Wh/km"`)

`ENERGY_DISTANCE` accepts the `Wh/km` unit and gives users automatic unit-system conversion (mi/kWh, kWh/100km, km/kWh).

## Impact

The existing long-term-statistics series for this one sensor resets on upgrade — intended; the previous accumulator series was incorrect. No other metric is affected.

## Tests

`scripts/tests/test_battery_consumption_metric.py` asserts the `ENERGY_DISTANCE` device_class, `MEASUREMENT` state_class, and the `Wh/km` unit constant via the real `get_metric_by_path`. Black clean; pylint ≥ 9.0; live-verified in a running HA.
