### PR TITLE
Check JSON booleans before the int/float branch in parse_value

### DIFF
--- a/custom_components/ovms/sensor/parsers.py
+++ b/custom_components/ovms/sensor/parsers.py
@@ -286,6 +286,15 @@ def parse_value(
                 return None
             return str(json_val)
 
+        # Booleans first: bool is a subclass of int, so a JSON true/false on a
+        # numeric sensor must be converted to 1/0 here. Otherwise it falls into
+        # the int/float branch below and is returned as Python True/False, which
+        # HA renders as the string "True"/"False" for a numeric sensor.
+        if isinstance(json_val, bool):
+            if requires_numeric_value(device_class, state_class):
+                return 1 if json_val else 0
+            return json_val
+
         # If JSON is a scalar, use it directly
         if isinstance(json_val, (int, float)):
             return json_val
@@ -304,12 +313,6 @@ def parse_value(
                     return float(json_val)
                 except (ValueError, TypeError):
                     return None
-            return json_val
-
-        if isinstance(json_val, bool):
-            # If we need a numeric value, convert bool to int
-            if requires_numeric_value(device_class, state_class):
-                return 1 if json_val else 0
             return json_val
 
         # For arrays or other types, convert to string if not numeric

--- a/scripts/tests/test_json_bool_parsing.py
+++ b/scripts/tests/test_json_bool_parsing.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Regression test for boolean handling in parse_value.
+
+``bool`` is a subclass of ``int``, so an ``isinstance(value, (int, float))``
+check matches booleans. The dedicated ``isinstance(value, bool)`` branch sat
+*after* that check and was therefore unreachable: a Python ``True``/``False``
+reaching the scalar branches was returned as-is (rendered "True" for a numeric
+sensor) instead of being converted to 1/0.
+
+The fix moves the bool check ahead of the int/float check. String "true"/
+"false" payloads were already handled earlier (parse_value lines ~233-236), so
+this only affects already-typed boolean values; both paths are covered here.
+
+Run standalone:  python3 scripts/tests/test_json_bool_parsing.py
+Exits non-zero on failure.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+from custom_components.ovms.sensor.parsers import parse_value
+
+NUM = dict(
+    device_class=SensorDeviceClass.POWER, state_class=SensorStateClass.MEASUREMENT
+)
+
+
+def _check(name, got, want, results):
+    ok = got == want and type(got) is type(want)
+    results.append(ok)
+    print(
+        f"  {'PASS' if ok else 'FAIL'}  {name}: {got!r}"
+        + ("" if ok else f" != {want!r}")
+    )
+
+
+def main():
+    print("OVMS parse_value boolean handling regression test")
+    print("-" * 55)
+    results = []
+
+    # A real boolean on a numeric sensor must become 1/0, not Python True/False.
+    _check("bool True on numeric sensor -> 1", parse_value(True, **NUM), 1, results)
+    _check("bool False on numeric sensor -> 0", parse_value(False, **NUM), 0, results)
+
+    # The common case (string payloads) keeps working.
+    _check(
+        'string "true" on numeric sensor -> 1', parse_value("true", **NUM), 1, results
+    )
+    _check(
+        'string "false" on numeric sensor -> 0', parse_value("false", **NUM), 0, results
+    )
+
+    # Plain numbers are unaffected.
+    _check('string "12.5" -> 12.5', parse_value("12.5", **NUM), 12.5, results)
+    _check('string "1" -> 1 (int)', parse_value("1", **NUM), 1, results)
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

In `parse_value`, `bool` is a subclass of `int`, so the `isinstance(value, (int, float))` check matched booleans — and the dedicated `isinstance(value, bool)` branch sat *after* it, making it unreachable. A real `True`/`False` reaching the scalar branches was returned as-is (rendered `"True"` on a numeric sensor) instead of `1`/`0`.

Note: string `"true"`/`"false"` payloads are already converted to `1`/`0` earlier in `parse_value` (the yes/no/true/false handling), so the common MQTT case was never affected. This only touches already-typed boolean values (e.g. a boolean extracted from a JSON object), and removes the dead branch.

## Fix

Move the `bool` check ahead of the `int/float` check and delete the now-redundant trailing branch.

## Tests

`scripts/tests/test_json_bool_parsing.py` drives the real `parse_value`: boolean `True`/`False` on a numeric sensor now return `int` `1`/`0` (type-checked, not `bool`), string `"true"/"false"` still return `1`/`0`, and plain numbers are unaffected. All pass; `black` clean. (parsers.py pylint improves 7.80 → 8.54 by dropping the dead branch.)