### PR TITLE
Tidy command handler: cancel cleanup task, drop dead import, use constants

### DIFF
--- a/custom_components/ovms/const.py
+++ b/custom_components/ovms/const.py
@@ -341,6 +341,9 @@ ERROR_UNKNOWN = "unknown"
 DEFAULT_COMMAND_RATE_LIMIT = 5  # commands per minute
 DEFAULT_COMMAND_RATE_PERIOD = 60.0  # seconds
 DEFAULT_COMMAND_TIMEOUT = 10  # seconds to wait for command response
+COMMAND_CLEANUP_INTERVAL = 60  # seconds between pending-command sweeps
+COMMAND_PENDING_EXPIRY = 300  # seconds before a pending command is expired
+COMMAND_CLEANUP_RETRY_DELAY = 5  # seconds to wait after a cleanup-loop error
 
 # Maximum length for state values in Home Assistant
 MAX_STATE_LENGTH = 255

--- a/custom_components/ovms/mqtt/__init__.py
+++ b/custom_components/ovms/mqtt/__init__.py
@@ -341,6 +341,10 @@ class OVMSMQTTClient:
         for listener_remove in getattr(self, "_cleanup_listeners", []):
             listener_remove()
 
+        # Cancel the command handler's background cleanup task
+        if hasattr(self, "command_handler"):
+            await self.command_handler.async_shutdown()
+
         # Shutdown staleness manager
         if hasattr(self, "staleness_manager"):
             await self.staleness_manager.async_shutdown()

--- a/custom_components/ovms/mqtt/command_handler.py
+++ b/custom_components/ovms/mqtt/command_handler.py
@@ -16,9 +16,12 @@ from ..const import (
     CONF_VEHICLE_ID,
     DEFAULT_COMMAND_RATE_LIMIT,
     DEFAULT_COMMAND_RATE_PERIOD,
+    DEFAULT_COMMAND_TIMEOUT,
     DEFAULT_QOS,
     COMMAND_TOPIC_TEMPLATE,
-    RESPONSE_TOPIC_TEMPLATE,
+    COMMAND_CLEANUP_INTERVAL,
+    COMMAND_PENDING_EXPIRY,
+    COMMAND_CLEANUP_RETRY_DELAY,
     PIN_SENSITIVE_COMMANDS,
     SENSITIVE_LOG_REDACTION,
 )
@@ -93,15 +96,16 @@ class CommandHandler:
         """Periodically clean up timed-out command requests."""
         while True:
             try:
-                # Run every 60 seconds
-                await asyncio.sleep(60)
+                await asyncio.sleep(COMMAND_CLEANUP_INTERVAL)
 
                 current_time = time.time()
                 expired_commands = []
 
                 for command_id, command_data in self.pending_commands.items():
-                    # Check if command is older than 5 minutes
-                    if current_time - command_data["timestamp"] > 300:
+                    if (
+                        current_time - command_data["timestamp"]
+                        > COMMAND_PENDING_EXPIRY
+                    ):
                         expired_commands.append(command_id)
                         _LOGGER.debug("Cleaning up expired command: %s", command_id)
 
@@ -124,7 +128,17 @@ class CommandHandler:
             except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.exception("Error in command cleanup task: %s", ex)
                 # Wait a bit before retrying to avoid tight loop
-                await asyncio.sleep(5)
+                await asyncio.sleep(COMMAND_CLEANUP_RETRY_DELAY)
+
+    async def async_shutdown(self) -> None:
+        """Cancel the background cleanup task on teardown."""
+        if self._cleanup_task is not None:
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+            self._cleanup_task = None
 
     def _get_connection_manager(self, vehicle_id: str = None):
         """Return the MQTT connection manager for the targeted vehicle.
@@ -152,7 +166,7 @@ class CommandHandler:
         command: str,
         parameters: str = "",
         command_id: str = None,
-        timeout: int = 10,
+        timeout: int = DEFAULT_COMMAND_TIMEOUT,
         vehicle_id: str = None,
     ) -> Dict[str, Any]:
         """Send a command to the OVMS module and wait for a response."""

--- a/scripts/tests/test_command_handler_shutdown.py
+++ b/scripts/tests/test_command_handler_shutdown.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regression test for CommandHandler background-task cleanup.
+
+CommandHandler starts a background ``_async_cleanup_pending_commands`` task in
+__init__ but never cancelled it, so each config-entry reload leaked a task.
+This test asserts the new ``async_shutdown`` cancels it (and is idempotent), and
+that the command timeout default is sourced from the constant.
+
+Run standalone:  python3 scripts/tests/test_command_handler_shutdown.py
+Exits non-zero on failure.
+"""
+
+import asyncio
+import inspect
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from custom_components.ovms.mqtt.command_handler import CommandHandler
+from custom_components.ovms.const import CONF_VEHICLE_ID, DEFAULT_COMMAND_TIMEOUT
+
+
+class _FakeHass:
+    def __init__(self):
+        self.data = {}
+
+
+def _check(name, cond, results):
+    results.append(cond)
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+
+async def main():
+    print("OVMS CommandHandler shutdown regression test")
+    print("-" * 55)
+    results = []
+
+    handler = CommandHandler(_FakeHass(), {CONF_VEHICLE_ID: "x"})
+    _check(
+        "cleanup task is started in __init__",
+        handler._cleanup_task is not None and not handler._cleanup_task.done(),
+        results,
+    )
+
+    await handler.async_shutdown()
+    _check(
+        "async_shutdown cancels and clears the cleanup task",
+        handler._cleanup_task is None,
+        results,
+    )
+
+    # idempotent (e.g. double teardown) must not raise
+    await handler.async_shutdown()
+    _check("async_shutdown is idempotent", True, results)
+
+    sig = inspect.signature(CommandHandler.async_send_command)
+    _check(
+        "command timeout default comes from DEFAULT_COMMAND_TIMEOUT",
+        sig.parameters["timeout"].default == DEFAULT_COMMAND_TIMEOUT,
+        results,
+    )
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Changes

Three small, related cleanups in the command handler (from the codebase audit):

1. **Task leak** — `_async_cleanup_pending_commands` is started in `__init__` but was never cancelled, so every config-entry reload left a lingering background task. Add `CommandHandler.async_shutdown()` to cancel it and call it from `OVMSMQTTClient.async_shutdown()`.
2. **Dead import** — remove the unused `RESPONSE_TOPIC_TEMPLATE` import (response routing is done by substring match in `mqtt/__init__.py`).
3. **Hardcoded numbers** — move the cleanup interval (`60`), pending-command expiry (`300`) and retry delay (`5`) to named `const.py` constants (`COMMAND_CLEANUP_INTERVAL`, `COMMAND_PENDING_EXPIRY`, `COMMAND_CLEANUP_RETRY_DELAY`), and source the `async_send_command` timeout default from the existing `DEFAULT_COMMAND_TIMEOUT` instead of a literal `10`.

No behavior change beyond the task now being cancelled on teardown.

## Tests

`scripts/tests/test_command_handler_shutdown.py` asserts the cleanup task is started, that `async_shutdown` cancels and clears it (and is idempotent), and that the timeout default comes from the constant. All pass; `black` clean; `pylint` 9.72/10 on the changed module.