### PR TITLE
Metrics consistency: single Ah constant, align Smart ForTwo name

### DIFF
--- a/custom_components/ovms/const.py
+++ b/custom_components/ovms/const.py
@@ -15,6 +15,9 @@ CONFIG_VERSION = 6
 OVMS_DEVICE_MANUFACTURER = "Open Vehicles"
 OVMS_DEVICE_MODEL = "OVMS Module"
 
+# Custom measurement units without a Home Assistant constant.
+UNIT_AMPERE_HOUR = "Ah"
+
 # Configuration
 CONF_VEHICLE_ID = "vehicle_id"
 CONF_QOS = "qos"

--- a/custom_components/ovms/metrics/__init__.py
+++ b/custom_components/ovms/metrics/__init__.py
@@ -80,9 +80,6 @@ from ..const import (
     CATEGORY_RENAULT_TWIZY,
 )
 
-# Custom unit constants
-UNIT_AMPERE_HOUR = "Ah"
-
 # Combine all metrics into the master dictionary
 METRIC_DEFINITIONS = {
     **BATTERY_METRICS,

--- a/custom_components/ovms/metrics/common/battery.py
+++ b/custom_components/ovms/metrics/common/battery.py
@@ -18,8 +18,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 
-# Custom unit constants
-UNIT_AMPERE_HOUR = "Ah"
+from ...const import UNIT_AMPERE_HOUR
 
 # Battery related metrics
 BATTERY_METRICS = {

--- a/custom_components/ovms/metrics/vehicles/mg_zs_ev.py
+++ b/custom_components/ovms/metrics/vehicles/mg_zs_ev.py
@@ -25,9 +25,6 @@ VEHICLE_TYPE = "mg_zs_ev"
 VEHICLE_NAME = "MG ZS EV"
 METRIC_PREFIX = "xmg."
 
-# Custom unit constants
-UNIT_AMPERE_HOUR = "Ah"
-
 # MG ZS-EV specific metrics
 MG_ZS_EV_METRICS = {
     # Battery system metrics

--- a/custom_components/ovms/metrics/vehicles/nissan_leaf.py
+++ b/custom_components/ovms/metrics/vehicles/nissan_leaf.py
@@ -21,9 +21,6 @@ VEHICLE_TYPE = "nissan_leaf"
 VEHICLE_NAME = "Nissan Leaf"
 METRIC_PREFIX = "xnl."
 
-# Custom unit constants
-UNIT_AMPERE_HOUR = "Ah"
-
 # Nissan Leaf specific metrics
 NISSAN_LEAF_METRICS = {
     # BMS metrics

--- a/custom_components/ovms/metrics/vehicles/renault_twizy.py
+++ b/custom_components/ovms/metrics/vehicles/renault_twizy.py
@@ -25,9 +25,6 @@ VEHICLE_TYPE = "renault_twizy"
 VEHICLE_NAME = "Renault Twizy"
 METRIC_PREFIX = "xrt."
 
-# Custom unit constants
-UNIT_AMPERE_HOUR = "Ah"
-
 # Renault Twizy specific metrics
 RENAULT_TWIZY_METRICS = {
     # Battery metrics

--- a/custom_components/ovms/metrics/vehicles/smart_fortwo.py
+++ b/custom_components/ovms/metrics/vehicles/smart_fortwo.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
 
 # Vehicle metadata
 VEHICLE_TYPE = "smart_fortwo"
-VEHICLE_NAME = "Smart EQ fortwo"
+VEHICLE_NAME = "Smart ForTwo"
 METRIC_PREFIX = "xse."
 
 # Smart ForTwo specific metrics

--- a/custom_components/ovms/metrics/vehicles/vw_eup.py
+++ b/custom_components/ovms/metrics/vehicles/vw_eup.py
@@ -25,9 +25,6 @@ VEHICLE_TYPE = "vw_eup"
 VEHICLE_NAME = "VW e-UP!"
 METRIC_PREFIX = "xvu."
 
-# Custom unit constants
-UNIT_AMPERE_HOUR = "Ah"
-
 # VW e-UP specific metrics
 VW_EUP_METRICS = {
     "xvu.b.cap.ah.abs": {

--- a/scripts/tests/test_metrics_consistency.py
+++ b/scripts/tests/test_metrics_consistency.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Regression test for metrics module consistency.
+
+- ``UNIT_AMPERE_HOUR`` is now a single source of truth in const.py (it was
+  duplicated in six metric modules; five copies were unused).
+- The Smart ForTwo ``VEHICLE_NAME`` matches the canonical label used for its
+  entity names (``VEHICLE_TOPIC_PREFIXES["xsq"]``).
+
+Run standalone:  python3 scripts/tests/test_metrics_consistency.py
+Exits non-zero on failure.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from custom_components.ovms.const import UNIT_AMPERE_HOUR, VEHICLE_TOPIC_PREFIXES
+from custom_components.ovms.metrics import get_metric_by_path
+from custom_components.ovms.metrics.vehicles.smart_fortwo import VEHICLE_NAME
+
+
+def _check(name, cond, results):
+    results.append(cond)
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+
+def main():
+    print("OVMS metrics consistency regression test")
+    print("-" * 55)
+    results = []
+
+    _check("UNIT_AMPERE_HOUR const is 'Ah'", UNIT_AMPERE_HOUR == "Ah", results)
+    _check(
+        "battery Ah metric resolves the shared constant",
+        get_metric_by_path("v.b.cac")["unit"] == UNIT_AMPERE_HOUR,
+        results,
+    )
+    _check(
+        "Smart ForTwo VEHICLE_NAME matches the canonical label",
+        VEHICLE_NAME == VEHICLE_TOPIC_PREFIXES["xsq"] == "Smart ForTwo",
+        results,
+    )
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Changes

Two small metrics-module consistency fixes from the audit:

1. **`UNIT_AMPERE_HOUR` single source of truth** — the constant `"Ah"` was defined in **six** modules (`metrics/__init__.py`, `metrics/common/battery.py`, and the four vehicle files). Only `battery.py` actually used it; the other five copies were dead. Define it once in `const.py`, import it in `battery.py`, and remove the five dead copies.
2. **Smart ForTwo `VEHICLE_NAME`** — was `"Smart EQ fortwo"` while every entity name and `const.VEHICLE_TOPIC_PREFIXES["xsq"]` use `"Smart ForTwo"`. Aligned so the config-flow discovery label matches the entities.

No behavior change (the `"Ah"` value is identical everywhere; `VEHICLE_NAME` only affects the setup-dialog display label).

## Tests

`scripts/tests/test_metrics_consistency.py` asserts the shared constant resolves for an Ah metric and that `VEHICLE_NAME` matches the canonical `"Smart ForTwo"` label. All pass; `black` clean; aggregate `pylint` 9.30/10 (≥9.0), battery.py 10.00/10, smart_fortwo.py unchanged at 8.57.