### PR TITLE
Remove dead and redundant code

### DIFF
--- a/custom_components/ovms/config_flow/options_flow.py
+++ b/custom_components/ovms/config_flow/options_flow.py
@@ -71,7 +71,8 @@ class OVMSOptionsFlow(OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize options flow."""
-        self._config_entry = config_entry
+        # Note: the base OptionsFlow exposes the entry via self.config_entry;
+        # don't store it again (assigning self.config_entry is deprecated).
         _LOGGER.debug("Initializing options flow for entry: %s", config_entry.entry_id)
 
     def _get_clean_blacklist_display(self, entry_options, entry_data):

--- a/custom_components/ovms/mqtt/entity_factory.py
+++ b/custom_components/ovms/mqtt/entity_factory.py
@@ -354,28 +354,6 @@ class EntityFactory:
                 self.config.get(CONF_VEHICLE_ID, "unknown"),
             )
 
-    def _get_metric_path_from_topic(self, topic: str) -> str:
-        """Extract metric path from topic."""
-        topic_suffix = topic
-        if topic.count("/") >= 3:  # Skip the prefix part
-            parts = topic.split("/")
-            # Find where the actual metric path starts
-            for i, part in enumerate(parts):
-                if part in [
-                    "metric",
-                    "status",
-                    "notify",
-                    "command",
-                    "m",
-                    "v",
-                    "s",
-                    "t",
-                ]:
-                    topic_suffix = "/".join(parts[i:])
-                    break
-
-        return topic_suffix.replace("/", ".")
-
     async def async_process_queued_entities(self) -> None:
         """Process any queued entities."""
         self.platforms_loaded = True

--- a/custom_components/ovms/sensor/binary_sensor.py
+++ b/custom_components/ovms/sensor/binary_sensor.py
@@ -172,8 +172,10 @@ class OVMSBinarySensor(BinarySensorEntity, RestoreEntity):
             def update_state(payload: str) -> None:
                 """Update the sensor state."""
                 try:
-                    # Ensure payload is properly truncated if it's a string
-                    if isinstance(payload, str) and len(payload) > 255:
+                    # Truncate over-long string payloads before parsing.
+                    # truncate_state_value enforces MAX_STATE_LENGTH internally,
+                    # so no separate length check / hardcoded limit is needed.
+                    if isinstance(payload, str):
                         truncated_payload = truncate_state_value(payload)
                         payload = (
                             truncated_payload


### PR DESCRIPTION
## Changes

Three small dead/redundant-code removals from the audit:

- **`mqtt/entity_factory.py`** — delete the unused `_get_metric_path_from_topic` method. It has no callers (the only other method of that name is a separate one on the binary-sensor class).
- **`config_flow/options_flow.py`** — drop the dead `self._config_entry` field. It's assigned in `__init__` but never read; all reads use the base `OptionsFlow.config_entry` property (re-assigning `self.config_entry` would be the deprecated pattern, so it correctly isn't done).
- **`sensor/binary_sensor.py`** — drop the redundant `len(payload) > 255` guard before `truncate_state_value(...)`, which already enforces `MAX_STATE_LENGTH` internally. Removes the hardcoded `255`.

No behavior change. Imports verified; `black` clean; `pylint` 9.03/10 across the three files.

### Noted separately (not in this PR)
While checking the options flow I found that the blacklist-conversion block inside the `if "Port" in user_input` branch *shadows* the dedup block below it (once it converts the value to a list, the later `isinstance(str)` check fails, so duplicates are never removed). That's a latent behavior bug rather than dead code, so I left it for a separate, deliberately-tested change.