### PR TITLE
Deduplicate the topic blacklist on every options-flow submit

### DIFF
--- a/custom_components/ovms/config_flow/options_flow.py
+++ b/custom_components/ovms/config_flow/options_flow.py
@@ -167,18 +167,12 @@ class OVMSOptionsFlow(OptionsFlow):
                 if "verify_ssl_certificate" in user_input:
                     del user_input["verify_ssl_certificate"]
 
-                # Process topic blacklist (convert to a list for storage)
-                if CONF_TOPIC_BLACKLIST in user_input and isinstance(
-                    user_input[CONF_TOPIC_BLACKLIST], str
-                ):
-                    blacklist = [
-                        x.strip()
-                        for x in user_input[CONF_TOPIC_BLACKLIST].split(",")
-                        if x.strip()
-                    ]
-                    user_input[CONF_TOPIC_BLACKLIST] = blacklist
-
-            # Process the blacklist string input
+            # Process the topic blacklist (string -> deduplicated list). This runs
+            # for every submit, including when a "Port" was selected above: the
+            # previous in-port-branch conversion turned the value into a list first,
+            # which made this isinstance(str) check fail and silently skipped the
+            # dedup, so duplicate patterns were stored. Keep a single conversion
+            # here so duplicates are always removed.
             if CONF_TOPIC_BLACKLIST in user_input and isinstance(
                 user_input[CONF_TOPIC_BLACKLIST], str
             ):

--- a/scripts/tests/test_options_blacklist_dedup.py
+++ b/scripts/tests/test_options_blacklist_dedup.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Regression test for topic-blacklist de-duplication in the options flow.
+
+The options form always includes a "Port" selector, so ``async_step_init`` took
+the ``if "Port" in user_input:`` branch on every submit. That branch converted
+the blacklist string into a list *without* de-duplicating, after which the
+dedicated de-dup block below it was skipped (its ``isinstance(..., str)`` guard
+now saw a list), so duplicate patterns were stored verbatim.
+
+This drives the REAL ``OVMSOptionsFlow.async_step_init`` with a Port selection
+and a blacklist containing duplicates, and asserts the saved blacklist is
+de-duplicated.
+
+Run standalone:  python3 scripts/tests/test_options_blacklist_dedup.py
+Exits non-zero on failure.
+"""
+
+# pylint: disable=duplicate-code
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from custom_components.ovms.config_flow.options_flow import OVMSOptionsFlow
+from custom_components.ovms.const import CONF_TOPIC_BLACKLIST
+
+
+class _FakeEntry:
+    """Minimal config-entry stand-in (only entry_id is read in __init__)."""
+
+    entry_id = "test_entry"
+    data = {}
+    options = {}
+
+
+def _check(name, cond, results):
+    results.append(cond)
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+
+async def main():
+    print("OVMS options-flow blacklist de-dup regression test")
+    print("-" * 55)
+    results = []
+
+    flow = OVMSOptionsFlow(_FakeEntry())
+    captured = {}
+    # Capture what async_step_init would persist instead of creating a real entry.
+    flow.async_create_entry = lambda **kw: captured.update(kw) or kw
+
+    await flow.async_step_init(
+        {"Port": "1883", CONF_TOPIC_BLACKLIST: "log, log, xyz ,xyz,, log"}
+    )
+    stored = captured.get("data", {}).get(CONF_TOPIC_BLACKLIST)
+
+    _check("blacklist is stored as a list", isinstance(stored, list), results)
+    _check(
+        f"duplicates removed, order preserved (got {stored!r})",
+        stored == ["log", "xyz"],
+        results,
+    )
+
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
The options form always includes the "Port" selector, so `async_step_init`
entered the `if "Port" in user_input:` branch on every submit. That branch
converted the blacklist string into a list **without** de-duplicating, and the
dedicated de-dup block below it was then skipped — its `isinstance(..., str)`
guard now saw a list — so duplicate blacklist patterns were stored verbatim.

Remove the redundant in-branch conversion and let the single de-dup block
process the blacklist string for every submit, so duplicates are always
removed. Add a regression test that drives the real
`OVMSOptionsFlow.async_step_init` with a Port selection plus a blacklist
containing duplicates and asserts the stored list is de-duplicated.
