### PR TITLE
Give controllable-metric switches a distinct display name

### DIFF
--- a/custom_components/ovms/const.py
+++ b/custom_components/ovms/const.py
@@ -93,8 +93,15 @@ LOCK_PIN_REQUIRED_ERROR = "A PIN code is required for lock and unlock commands."
 # These metrics automatically create switch entities alongside their sensors.
 # The dictionary key is the metric path (e.g., "v.e.hvac").
 # Source: OVMS command documentation for controllable vehicle features.
+# Each entry's "name" is the control switch's own display name. It MUST differ
+# from the status sensor created for the same metric (e.g. the "Charging Status"
+# binary sensor for v.c.charging) or both entities render the identical name on
+# the device page. TopicParser._build_related_control_entity passes this through
+# as the switch's friendly_name; without it the switch fell back to the status
+# sensor's name and collided with it.
 SWITCH_TYPES = {
     "v.e.hvac": {
+        "name": "Climate Control",
         "type": "climate",
         "icon": "mdi:thermometer",
         "category": None,
@@ -102,6 +109,7 @@ SWITCH_TYPES = {
         "off_command": "climatecontrol off",
     },
     "v.c.charging": {
+        "name": "Charge Control",
         "type": "charge",
         "icon": "mdi:battery-charging",
         "category": None,
@@ -109,6 +117,7 @@ SWITCH_TYPES = {
         "off_command": "charge stop",
     },
     "v.e.valet": {
+        "name": "Valet Control",
         "type": "valet",
         "icon": "mdi:key",
         "category": None,

--- a/scripts/tests/test_control_switch_names.py
+++ b/scripts/tests/test_control_switch_names.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Regression test: controllable-metric switches have a distinct display name.
+
+Each metric in ``SWITCH_TYPES`` gets a control switch created alongside its
+status sensor (e.g. ``v.c.charging`` -> a "Charging Status" binary sensor **and**
+a charge on/off switch). The switch's friendly_name comes from
+``SWITCH_TYPES[...]["name"]`` (``TopicParser._build_related_control_entity``).
+Those entries had no ``"name"``, so the switch fell back to the status sensor's
+name and both rendered identically on the device page.
+
+This asserts every switch now defines a name that differs from its status
+sensor's name.
+
+Run standalone:  python3 scripts/tests/test_control_switch_names.py
+Exits non-zero on failure.
+"""
+
+# pylint: disable=duplicate-code
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from custom_components.ovms.const import SWITCH_TYPES
+from custom_components.ovms.metrics import get_metric_by_path
+
+
+def _check(name, cond, results):
+    results.append(cond)
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+
+def main():
+    print("OVMS control-switch name distinctness test")
+    print("-" * 55)
+    results = []
+    for metric_path, cfg in SWITCH_TYPES.items():
+        switch_name = cfg.get("name")
+        _check(
+            f"{metric_path}: switch defines a non-empty name",
+            bool(switch_name),
+            results,
+        )
+        status = get_metric_by_path(metric_path)
+        status_name = status.get("name") if status else None
+        if status_name:
+            _check(
+                f"{metric_path}: switch {switch_name!r} != status {status_name!r}",
+                switch_name != status_name,
+                results,
+            )
+    print("-" * 55)
+    if all(results):
+        print(f"All {len(results)} checks passed.")
+        return 0
+    print(f"{results.count(False)} of {len(results)} checks FAILED.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Each metric in `SWITCH_TYPES` gets a control switch created alongside its status
sensor (e.g. `v.c.charging` -> a "Charging Status" binary sensor **and** a charge
on/off switch). The switch's friendly_name comes from `SWITCH_TYPES[...]["name"]`
(`TopicParser._build_related_control_entity`), but those entries had no `"name"`,
so every control switch fell back to its status sensor's name and the two
rendered with the identical name on the device page (e.g. two "Charging Status"
entities per vehicle).

Add a distinct name to each control switch — "Climate Control", "Charge
Control", "Valet Control" — each different from its status sensor ("HVAC
Active", "Charging Status", "Valet Mode"). Add a regression test asserting every
switch defines a name that differs from its status sensor's name.
