### PR TITLE
Raise minimum to Home Assistant 2025.2.5 / Python 3.13

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -354,7 +354,7 @@ client_id = f"ha_ovms_{hash[:12]}"
 
 - `paho-mqtt>=1.6.1`: MQTT client (do NOT use aiomqtt or asyncio-mqtt)
 - Home Assistant 2025.2.5+
-- Python 3.12+
+- Python 3.13+
 
 **Important**: Use synchronous paho-mqtt with manual event loop integration via `hass.loop.run_in_executor()` for blocking calls.
 

--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 paho-mqtt>=1.6.1
-homeassistant>=2025.1.4
+homeassistant>=2025.2.5
 pylint>=2.17.0
 voluptuous>=0.13.1


### PR DESCRIPTION
`hacs.json` already declares a 2025.2.5 minimum, but `requirements.txt` floored
at `homeassistant>=2025.1.4` and CI ran on Python 3.12 — which caps the
installable HA at 2025.1.4 (HA 2025.2+ requires Python 3.13). So CI tested an
older HA than the declared minimum and blocked APIs added in 2025.2 (e.g.
`SensorDeviceClass.ENERGY_DISTANCE` / `UnitOfEnergyDistance`).

Align `requirements.txt` to `>=2025.2.5` and bump the CI Python matrix (pylint,
code-formatting, release-testing) to 3.13 so CI tests the actual supported
configuration, and update the documented Python floor to 3.13+.
