### PR TITLE
Let pylint resolve test imports via init-hook

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,6 +7,14 @@
 # code. That noise can push the score under the gate when a new test is added.
 # Disable duplicate-code repo-wide; genuine duplication is caught in review.
 
+[MAIN]
+# Add the repo root to sys.path so pylint can resolve the `custom_components`
+# imports that the standalone scripts/tests/*.py harnesses use after a runtime
+# sys.path.insert (which pylint does not execute). Without this every test file
+# reports false-positive import-error / wrong-import-position, which drags the
+# global score under the --fail-under gate as more test files are added.
+init-hook='import sys; sys.path.insert(0, ".")'
+
 [MESSAGES CONTROL]
 disable=
     duplicate-code


### PR DESCRIPTION
The standalone `scripts/tests/*.py` harnesses import `custom_components.*` after
a runtime `sys.path.insert`, which pylint does not execute — so every test file
produced false-positive `import-error` / `wrong-import-position` messages (~95
total), dragging the global score under the `--fail-under=9.0` gate as more
tests were added.

Add a pylint `init-hook` that puts the repo root on `sys.path` so pylint
resolves those imports (score 8.99 -> 9.33, import-error count 95 -> 0). This
removes the near-9.0 fragility for future test PRs.
