### PR TITLE
Render undeclared numeric vectors as median + attributes

### DIFF
--- a/custom_components/ovms/const.py
+++ b/custom_components/ovms/const.py
@@ -164,10 +164,6 @@ SYSTEM_TOPIC_BLACKLIST = [
     "server/web/socket",
     "egpio/output",
     "power/can1",
-    # VW e-Up 6x8 SOC/temperature park-time matrix (OVMS 3.3.006): a 48-value
-    # vector with no meaningful single sensor state (>255 char raw value); its
-    # useful aggregates are exposed as the xvu.b.time.* scalars instead.
-    "xvu/b/time/parked/state",
 ]
 
 # Legacy topic blacklist patterns - kept for migration compatibility
@@ -359,6 +355,14 @@ COMMAND_CLEANUP_RETRY_DELAY = 5  # seconds to wait after a cleanup-loop error
 
 # Maximum length for state values in Home Assistant
 MAX_STATE_LENGTH = 255
+
+# Minimum number of comma-separated numeric elements for a payload to be treated
+# as a data vector (median shown as the state, the full series exposed as
+# attributes) rather than a scalar string. 4+ avoids catching short tuples (GPS
+# pairs are handled separately, version triples, etc.) while covering real series
+# like the VW e-Up 48-value park-time matrix that would otherwise exceed
+# MAX_STATE_LENGTH and render as a truncated raw string.
+VECTOR_MIN_VALUES = 4
 
 # GPS accuracy calculation constants
 # Used to convert GPS signal quality (v.p.gpssq) to meters accuracy

--- a/custom_components/ovms/metrics/vehicles/vw_eup.py
+++ b/custom_components/ovms/metrics/vehicles/vw_eup.py
@@ -137,9 +137,10 @@ VW_EUP_METRICS = {
     # long-term statistics that make these accumulators useful. A plain numeric
     # sensor with unit d/h keeps them graphable.
     # The 6x8 SOC/temperature park-time matrix (xvu.b.time.parked.state) is a
-    # 48-value vector with no meaningful single sensor state, so it is
-    # suppressed via SYSTEM_TOPIC_BLACKLIST in const.py rather than surfaced as
-    # a broken/truncated entity; its useful aggregates are the scalars above.
+    # 48-value vector with no single natural scalar. The sensor platform renders
+    # any such numeric vector cleanly (median as the state, the full series as
+    # attributes - see OVMSSensor._try_parse_numeric_vector), so it is surfaced
+    # as a clean entity; its useful aggregates are also the scalars above.
     "xvu.b.time.charged.ac": {
         "name": "VW eUP! Battery Time Charged AC",
         "description": "Total lifetime time the battery has been AC charged",

--- a/custom_components/ovms/sensor/entities.py
+++ b/custom_components/ovms/sensor/entities.py
@@ -20,6 +20,7 @@ from homeassistant.util import dt as dt_util
 from ..const import (
     LOGGER_NAME,
     SIGNAL_UPDATE_ENTITY,
+    VECTOR_MIN_VALUES,
     get_add_entities_signal,
     truncate_state_value,
 )
@@ -500,20 +501,24 @@ class OVMSSensor(SensorEntity, RestoreEntity):
             self._attr_extra_state_attributes.get("original_state_class")
             or self._attr_state_class
         )
+        handled_numeric_vector = False
         if not self._try_parse_vector(initial_state):
-            self._parsed_value = parse_value(
-                initial_state,
-                device_class_for_parsing,
-                state_class_for_parsing,
-                self._is_cell_sensor,
-            )
+            if not self._is_cell_sensor:
+                handled_numeric_vector = self._try_parse_numeric_vector(initial_state)
+            if not handled_numeric_vector:
+                self._parsed_value = parse_value(
+                    initial_state,
+                    device_class_for_parsing,
+                    state_class_for_parsing,
+                    self._is_cell_sensor,
+                )
 
-            # Format the value
-            self._attr_native_value = format_sensor_value(
-                self._parsed_value,
-                device_class_for_parsing,
-                self._attr_extra_state_attributes,
-            )
+                # Format the value
+                self._attr_native_value = format_sensor_value(
+                    self._parsed_value,
+                    device_class_for_parsing,
+                    self._attr_extra_state_attributes,
+                )
 
         # Extract additional attributes
         if (
@@ -522,7 +527,7 @@ class OVMSSensor(SensorEntity, RestoreEntity):
             and "," in initial_state
         ):
             self._handle_cell_values(initial_state)
-        else:
+        elif not handled_numeric_vector:
             updated_attrs = process_json_payload(
                 initial_state,
                 self._attr_extra_state_attributes,
@@ -655,24 +660,29 @@ class OVMSSensor(SensorEntity, RestoreEntity):
                 self.async_write_ha_state()
                 return
 
-            self._parsed_value = parse_value(
-                payload,
-                device_class_for_parsing,
-                state_class_for_parsing,
-                self._is_cell_sensor,
-            )
+            handled_numeric_vector = False
+            if not self._is_cell_sensor:
+                handled_numeric_vector = self._try_parse_numeric_vector(payload)
 
-            # Format the value
-            self._attr_native_value = format_sensor_value(
-                self._parsed_value,
-                device_class_for_parsing,
-                self._attr_extra_state_attributes,
-            )
+            if not handled_numeric_vector:
+                self._parsed_value = parse_value(
+                    payload,
+                    device_class_for_parsing,
+                    state_class_for_parsing,
+                    self._is_cell_sensor,
+                )
+
+                # Format the value
+                self._attr_native_value = format_sensor_value(
+                    self._parsed_value,
+                    device_class_for_parsing,
+                    self._attr_extra_state_attributes,
+                )
 
             # Process the payload for attributes
             if self._is_cell_sensor and isinstance(payload, str) and "," in payload:
                 self._handle_cell_values(payload)
-            else:
+            elif not handled_numeric_vector:
                 updated_attrs = process_json_payload(
                     payload,
                     self._attr_extra_state_attributes,
@@ -726,6 +736,40 @@ class OVMSSensor(SensorEntity, RestoreEntity):
         self._parsed_value = state_value
         self._attr_native_value = state_value
         self._attr_extra_state_attributes.update(vector_attrs)
+        return True
+
+    def _try_parse_numeric_vector(self, payload: Any) -> bool:
+        """Render an undeclared comma-separated numeric vector cleanly.
+
+        Some OVMS metrics publish a comma-separated list of numbers (e.g. the VW
+        e-Up ``xvu.b.time.parked.state`` 6x8 park-time matrix) for which there is
+        no single natural scalar and whose raw form exceeds Home Assistant's
+        255-character state limit. Mirror the cell-sensor presentation: expose
+        the median as the state and the full series plus min/max/mean/count as
+        attributes. Only fires for a genuine numeric vector (>=
+        VECTOR_MIN_VALUES all-numeric elements) that no other handler claimed,
+        so scalars, short tuples and labelled vectors are unaffected. Returns
+        True when it handled the payload.
+        """
+        if not isinstance(payload, str) or "," not in payload:
+            return False
+        parts = [p.strip() for p in payload.split(",") if p.strip()]
+        if len(parts) < VECTOR_MIN_VALUES:
+            return False
+        try:
+            values = [float(p) for p in parts]
+        except (ValueError, TypeError):
+            return False
+
+        median = round(calculate_median(values), 4)
+        self._parsed_value = median
+        self._attr_native_value = median
+        self._attr_extra_state_attributes["values"] = values
+        self._attr_extra_state_attributes["count"] = len(values)
+        self._attr_extra_state_attributes["median"] = median
+        self._attr_extra_state_attributes["min"] = min(values)
+        self._attr_extra_state_attributes["max"] = max(values)
+        self._attr_extra_state_attributes["mean"] = round(sum(values) / len(values), 4)
         return True
 
     def _handle_cell_values(self, payload: str) -> None:

--- a/scripts/tests/test_vw_eup_battery_age.py
+++ b/scripts/tests/test_vw_eup_battery_age.py
@@ -105,8 +105,9 @@ def main():
         results,
     )
 
-    # The 48-value park-time matrix must be suppressed (blacklisted), while the
-    # scalar metrics must still create sensors.
+    # The 48-value park-time matrix is rendered as a clean numeric-vector sensor
+    # (median state + series attributes), no longer suppressed; the scalar
+    # metrics still create their own sensors.
     parser = TopicParser(
         {
             "vehicle_id": "eup",
@@ -118,14 +119,35 @@ def main():
     )
     base = "ovms/ovmsuser/eup/metric/xvu/b/time"
     _check(
-        "park-time matrix topic is suppressed (no entity)",
-        parser.parse_topic(f"{base}/parked/state", "1,2,3") is None,
+        "park-time matrix topic creates a sensor (rendered, not suppressed)",
+        (parser.parse_topic(f"{base}/parked/state", "0,1,2,3,4,5") or {}).get(
+            "entity_type"
+        )
+        == "sensor",
         results,
     )
     _check(
-        "scalar parked topic still creates a sensor (not over-blacklisted)",
+        "scalar parked topic also creates a sensor",
         (parser.parse_topic(f"{base}/parked", "300.25") or {}).get("entity_type")
         == "sensor",
+        results,
+    )
+
+    # The matrix renders cell-style: median as state, full series as attributes.
+    matrix_sensor = _TestSensor(
+        "ovms_test_eup_matrix",
+        "ovms_eup_matrix",
+        f"{base}/parked/state",
+        "0,2,4,6,8,10",
+        {},
+        {"category": "vw_eup"},
+        "Battery Time Parked State",
+        None,
+    )
+    _check(
+        "matrix sensor state is the median (5.0), not a raw vector string",
+        matrix_sensor.native_value == 5.0
+        and matrix_sensor.extra_state_attributes.get("count") == 6,
         results,
     )
 


### PR DESCRIPTION
Fixes the nasty raw-vector entity reported during release testing: a metric publishing a long comma-separated numeric vector (the VW e-Up `xvu.b.time.parked.state` 6x8 park-time matrix - **48 values, 267 chars**) was shown as its raw string state. That exceeds Home Assistant's 255-char state limit, so it rendered as a truncated, unusable entity, and was worked around by blacklisting the topic.

## Fix
Render any undeclared comma-separated numeric vector the way the **cell sensors** already do - one value as the state, the rest as attributes:
- `OVMSSensor._try_parse_numeric_vector`: median -> state; `values` (full series) + `count`/`median`/`min`/`max`/`mean` -> attributes.
- Gated on `>= VECTOR_MIN_VALUES` (4) all-numeric elements, and only when no other handler (cell sensor, labelled vector) claimed the payload - so scalars, GPS pairs, version triples and the `xsq.bms.contactor.cycles` labelled vector are unaffected.
- With a short numeric state the >255 issue disappears, so `xvu/b/time/parked/state` is **removed from `SYSTEM_TOPIC_BLACKLIST`** and surfaced as a clean entity (its scalar aggregates `xvu.b.time.*` remain).

## Verified
- Unit: 48-value matrix sensor -> state `11.75` (median) + `count=48` (test_vw_eup_battery_age.py updated).
- **Live**: the `B Time Parked State` entity now shows `11.75` with the full 48-value series + stats as attributes; zero raw-vector entities remain across all vehicles.
- Full suite green, pylint 9.33, black clean.