### PR TITLE
Release v1.7.0

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.6.4"
+  "version": "v1.7.0"
 }


### PR DESCRIPTION
# OVMS Home Assistant v1.7.0

Released on 2026-06-26

## Changes

* Remove accidentally-committed test artifacts; ignore them (#251) (181f2bd)
* Render undeclared numeric vectors as median + attributes (#250) (c06f4fe)
* Add Smart ED (451) as a distinct vehicle (#249) (7f710e2)
* Release-prep: enforce black on scripts/, drop legacy script, fix pre-existing nits (#248) (921993a)
* Fix Smart ForTwo vehicle detection (xsq prefix) (#230) (a9b68d8)
* Convert dict-extracted booleans to 1/0 on numeric sensors (#246) (bc6c9f9)
* Let pylint resolve test imports via init-hook (#247) (8998dac)
* Don't block the event loop during config-flow connection test (#231) (92d6f50)
* Type v.b.consumption as ENERGY_DISTANCE (Wh/km), not an energy total (#235) (20aae55)
* Raise minimum to Home Assistant 2025.2.5 / Python 3.13 (#245) (91da25e)

## Full Changelog
[v1.6.4...v1.7.0](https://github.com/enoch85/ovms-home-assistant/compare/v1.6.4...v1.7.0)
