### PR TITLE
Remove dead per-prefix branches in _convert_to_metric_path

### DIFF
--- a/custom_components/ovms/config_flow/topic_discovery.py
+++ b/custom_components/ovms/config_flow/topic_discovery.py
@@ -60,8 +60,8 @@ _LOGGER = logging.getLogger(LOGGER_NAME)
 def detect_vehicle_type(topics: Set[str]) -> tuple[str, str]:
     """Detect vehicle type from discovered topics.
 
-    Looks for vehicle-specific metric prefixes (xvu., xsq., xmg., xnl., xrt.)
-    in the topic paths to determine the vehicle type.
+    Looks for vehicle-specific metric prefixes (xvu., xsq., xse., xmg., xnl.,
+    xrt.) in the topic paths to determine the vehicle type.
 
     Note: MQTT topics use slashes (xvu/b/c/soh) while metric definitions use
     dots (xvu.b.c.soh), so we convert the prefix dots to slashes for matching.

--- a/custom_components/ovms/mqtt/topic_parser.py
+++ b/custom_components/ovms/mqtt/topic_parser.py
@@ -168,7 +168,7 @@ class TopicParser:
             if parts[0] == "client":
                 return None
 
-            # Handle vendor-specific prefixes (like xvu, xsq, xmg, xnl)
+            # Convert the topic parts into a dotted metric-definition path
             metric_path = self._convert_to_metric_path(parts)
 
             # Determine entity type and category
@@ -316,32 +316,19 @@ class TopicParser:
         }
 
     def _convert_to_metric_path(self, parts: list[str]) -> str:
-        """Convert topic parts to metric path."""
-        # Keep vendor-specific prefixes intact
-        if len(parts) >= 2:
-            # VW e-UP metrics
-            if "xvu" in parts:
-                return ".".join(parts)
+        """Convert topic parts to a dotted metric-definition path.
 
-            # Smart ForTwo metrics
-            if "xsq" in parts:
-                return ".".join(parts)
-
-            # MG ZS-EV metrics
-            if "xmg" in parts:
-                return ".".join(parts)
-
-            # Nissan Leaf metrics
-            if "xnl" in parts:
-                return ".".join(parts)
-
-            # Renault Twizy metrics
-            if "xrt" in parts:
-                return ".".join(parts)
-
-            # Metric specific prefixes
-            if parts[0] in ["metric", "status", "notify"]:
-                return ".".join(parts[1:])
+        Strips the leading topic-type segment ("metric"/"status"/"notify") so
+        the remainder matches the dotted keys in the metric definitions, e.g.
+        ``["metric", "xvu", "b", "soc"]`` -> ``"xvu.b.soc"``. This is uniform for
+        every vehicle prefix (xvu/xsq/xse/xmg/xnl/xrt) and the generic ``v.*``
+        metrics - no per-prefix special-casing is needed. (The previous per-prefix
+        branches just re-joined the same parts and left a spurious "metric."
+        prefix on those five cars, which ``get_metric_by_path`` then had to
+        tolerate; Smart ED never had a branch and resolved correctly here.)
+        """
+        if len(parts) >= 2 and parts[0] in ["metric", "status", "notify"]:
+            return ".".join(parts[1:])
 
         return ".".join(parts)
 


### PR DESCRIPTION
Follow-up cleanup from the v1.7.0 self-review (non-blocking; not in the v1.7.0 tag).

`_convert_to_metric_path` had a redundant `if "xXX" in parts: return ".".join(parts)` branch for each vehicle prefix (`xvu`/`xsq`/`xmg`/`xnl`/`xrt`). Each did exactly what the final fallback does — but because they ran **before** the `"metric"/"status"/"notify"` strip, they left a spurious `metric.` prefix on those five cars' metric paths (e.g. `metric.xvu.b.soc`), which `get_metric_by_path` then had to tolerate. Smart ED (`xse`) had no branch and already resolved correctly via the strip — so the asymmetry the review flagged was the *other five* being slightly wrong, not `xse`.

**Fix:** delete the dead branches so all six prefixes + generic `v.*` metrics resolve uniformly through the single strip, yielding clean dotted paths (`xvu.b.soc`).

**Proven behaviour-preserving:**
- Entity `name`/`unique_id` derive from the topic **parts**, not `metric_path` — so no entity is orphaned.
- Across **all 241 vehicle-prefix metrics**, binary/sensor classification is **unchanged (0 flips)**.
- Per-car `parse_topic` check: names, entity types and resolved metric definitions identical for all 6 cars; only `metric_path` is now clean.
- Full suite 18/18, file pylint 9.33 → 9.60, black clean.

Also adds `xse.` to the `detect_vehicle_type` docstring.