### PR TITLE
Run staleness cleanup as a background task so it doesn't block HA startup (#254)

### DIFF
--- a/custom_components/ovms/entity_staleness_manager.py
+++ b/custom_components/ovms/entity_staleness_manager.py
@@ -223,8 +223,15 @@ class EntityStalenessManager:
     def _start_cleanup_task(self) -> None:
         """Start the cleanup task."""
         if self._cleanup_task is None or self._cleanup_task.done():
-            self._cleanup_task = self.hass.async_create_task(
-                self._async_cleanup_stale_entities()
+            # Use a background task: this loop runs for the lifetime of the
+            # integration and never completes on its own. A normal
+            # async_create_task is tracked by HA's bootstrap, so the forever
+            # loop blocks "wrapping up the start up phase" (see issue #254).
+            # Background tasks are exempt from that wait and are auto-cancelled
+            # on shutdown.
+            self._cleanup_task = self.hass.async_create_background_task(
+                self._async_cleanup_stale_entities(),
+                name=f"ovms_staleness_cleanup_{self._vehicle_id}",
             )
             _LOGGER.debug("Started entity staleness cleanup task")
 


### PR DESCRIPTION
## Summary

Fixes #254 — on HA OS, after upgrading to v1.7.0, Home Assistant took several minutes to finish starting and logged:

```
Setup timed out for stage 2 waiting on {<Task ... _async_cleanup_stale_entities()>}
Something is blocking Home Assistant from wrapping up the start up phase.
```

## Root cause

`EntityStalenessManager._async_cleanup_stale_entities()` is a forever-running loop (initial wait, then `while not self._shutting_down: await asyncio.sleep(...)`). It was started with `hass.async_create_task()`, which registers the task in `hass._tasks`. HA's bootstrap **waits on** those tasks when wrapping up startup, so a task that never completes blocks the wrap-up until the bootstrap timeout fires.

Only users who **enabled** entity staleness management were affected (it is disabled by default).

## Fix

Use `hass.async_create_background_task()` instead. Per HA core, background tasks "will not block startup", "will be automatically cancelled on shutdown", and "async_block_till_done will not wait for completion" — exactly the semantics a lifetime background loop needs.

## Verification

- Runtime test against HA 2026.2.3: the task now lands in `hass._background_tasks` (not `hass._tasks`) and `async_block_till_done()` returns instantly; a negative control with the old `async_create_task` reproduces the hang.
- Live HA + Playwright with staleness enabled (48h): integration sets up cleanly, the background cleanup task runs and updates the diagnostic sensor (`sensor.*_staleness_status`), and **no "Setup timed out" / "blocking ... start up phase" warnings appear**.
- `scripts/tests/test_code_quality.py` and `black` pass.