### PR TITLE
Release v1.7.1

### DIFF
--- a/custom_components/ovms/manifest.json
+++ b/custom_components/ovms/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/enoch85/ovms-home-assistant/issues",
   "requirements": ["paho-mqtt>=1.6.1"],
-  "version": "v1.7.0"
+  "version": "v1.7.1"
 }


### PR DESCRIPTION
# OVMS Home Assistant v1.7.1

Released on 2026-06-28

## Changes

* Run staleness cleanup as a background task so it doesn't block HA startup (#255) (f4fdbdf)
* Remove dead per-prefix branches in _convert_to_metric_path (#253) (7da99ca)

## Full Changelog
[v1.7.0...v1.7.1](https://github.com/enoch85/ovms-home-assistant/compare/v1.7.0...v1.7.1)
